### PR TITLE
Fix local image rendering in preview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "remark-rehype": "^11.1.2",
         "tailwind-merge": "^3.3.0",
         "unified": "^11.0.5",
+        "unist-util-visit": "^5.1.0",
         "zustand": "^5.0.8"
       },
       "devDependencies": {
@@ -36,6 +37,7 @@
         "@eslint/js": "^9.39.0",
         "@playwright/test": "^1.58.2",
         "@tailwindcss/typography": "^0.5.16",
+        "@types/hast": "^3.0.4",
         "@types/node": "^24.10.0",
         "@types/react": "^19.2.2",
         "@types/react-dom": "^19.2.2",
@@ -3270,6 +3272,8 @@
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
@@ -11995,6 +11999,8 @@
     },
     "node_modules/unist-util-visit": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "remark-rehype": "^11.1.2",
     "tailwind-merge": "^3.3.0",
     "unified": "^11.0.5",
+    "unist-util-visit": "^5.1.0",
     "zustand": "^5.0.8"
   },
   "devDependencies": {
@@ -53,6 +54,7 @@
     "@eslint/js": "^9.39.0",
     "@playwright/test": "^1.58.2",
     "@tailwindcss/typography": "^0.5.16",
+    "@types/hast": "^3.0.4",
     "@types/node": "^24.10.0",
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app } from 'electron';
+import { app, protocol } from 'electron';
 import { join } from 'node:path';
 import { createAppMenu } from './menu';
 import { createMainWindow } from './window';
@@ -7,6 +7,11 @@ import { registerExportIpc } from './ipc/export';
 import { registerWindowIpc } from './ipc/window';
 import { registerSettingsIpc } from './ipc/settings';
 import { registerLocaleIpc } from './ipc/locale';
+import { LOCAL_ASSET_SCHEME, registerLocalAssetProtocol } from './protocol';
+
+protocol.registerSchemesAsPrivileged([
+  { scheme: LOCAL_ASSET_SCHEME, privileges: { supportFetchAPI: true, stream: true } },
+]);
 
 let mainWindow: ReturnType<typeof createMainWindow> | null = null;
 
@@ -26,6 +31,7 @@ async function bootstrap() {
   registerLocaleIpc(() => mainWindow);
 
   app.whenReady().then(() => {
+    registerLocalAssetProtocol();
     mainWindow = createMainWindow();
     createAppMenu(mainWindow);
     void loadMainWindow(mainWindow);

--- a/src/main/ipc/document.ts
+++ b/src/main/ipc/document.ts
@@ -67,6 +67,24 @@ export function registerDocumentIpc() {
     },
   );
 
+  ipcMain.handle(ipcChannels.pickImage, async () => {
+    const result = await dialog.showOpenDialog({
+      properties: ['openFile'],
+      filters: [
+        {
+          name: 'Images',
+          extensions: ['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'avif', 'bmp', 'ico'],
+        },
+      ],
+    });
+
+    if (result.canceled || result.filePaths.length === 0) {
+      return null;
+    }
+
+    return result.filePaths[0];
+  });
+
   ipcMain.handle(
     ipcChannels.saveDocumentAs,
     async (_, payload: SaveDocumentPayload) => {

--- a/src/main/protocol.ts
+++ b/src/main/protocol.ts
@@ -1,0 +1,41 @@
+import { net, protocol } from 'electron';
+import { resolve, normalize } from 'node:path';
+import { stat } from 'node:fs/promises';
+
+export const LOCAL_ASSET_SCHEME = 'local-asset';
+
+function isWithinDirectory(filePath: string, dir: string): boolean {
+  const normalizedFile = normalize(filePath);
+  const normalizedDir = normalize(dir) + (process.platform === 'win32' ? '\\' : '/');
+  return normalizedFile.startsWith(normalizedDir);
+}
+
+export function registerLocalAssetProtocol() {
+  protocol.handle(LOCAL_ASSET_SCHEME, async (request) => {
+    const url = new URL(request.url);
+
+    const baseDir = decodeURIComponent(url.searchParams.get('base') ?? '');
+    const relativePath = decodeURIComponent(url.searchParams.get('path') ?? '');
+
+    if (!baseDir || !relativePath) {
+      return new Response('Bad request', { status: 400 });
+    }
+
+    const resolved = resolve(baseDir, relativePath);
+
+    if (!isWithinDirectory(resolved, baseDir)) {
+      return new Response('Forbidden', { status: 403 });
+    }
+
+    try {
+      const fileStat = await stat(resolved);
+      if (!fileStat.isFile()) {
+        return new Response('Not found', { status: 404 });
+      }
+    } catch {
+      return new Response('Not found', { status: 404 });
+    }
+
+    return net.fetch(`file://${resolved}`);
+  });
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -41,6 +41,7 @@ const api: MarkyApi = {
   getLocale: () => ipcRenderer.invoke(ipcChannels.getLocale),
   updateMenuLanguage: (locale: Locale) =>
     ipcRenderer.invoke(ipcChannels.updateMenuLanguage, locale),
+  pickImage: () => ipcRenderer.invoke(ipcChannels.pickImage),
 };
 
 contextBridge.exposeInMainWorld('marky', api);

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -217,7 +217,7 @@ export function App() {
             {viewMode !== 'editor' && (
               <section ref={previewRef} className="app-preview-pane focus:outline-none" tabIndex={-1}>
                 <div data-preview-root className="mx-auto max-w-3xl px-8 py-10">
-                  <PreviewPane markdown={activeDocument.content} />
+                  <PreviewPane markdown={activeDocument.content} documentPath={activeDocument.path} />
                 </div>
               </section>
             )}

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -241,6 +241,7 @@ export function App() {
 
         <InsertAssetDialog
           dialog={insertDialog}
+          documentPath={activeDocument.path}
           onClose={handleInsertDialogClose}
           onInsert={handleInsertDialogSubmit}
         />

--- a/src/renderer/src/features/editor/components/insert-asset-dialog.tsx
+++ b/src/renderer/src/features/editor/components/insert-asset-dialog.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef, useState } from 'react';
-import { X } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { FolderOpen, TriangleAlert, X } from 'lucide-react';
 import { Button } from '@renderer/components/ui/button';
 import { useTranslation } from '@renderer/i18n';
 
@@ -22,6 +22,7 @@ export type InsertAssetPayload =
 
 type InsertAssetDialogProps = {
   dialog: InsertAssetDialogState;
+  documentPath?: string | null;
   onClose: () => void;
   onInsert: (payload: InsertAssetPayload) => void;
 };
@@ -34,8 +35,51 @@ const noDrag = {
   WebkitAppRegion: 'no-drag' as React.CSSProperties['WebkitAppRegion'],
 };
 
+function isLocalPath(value: string): boolean {
+  if (!value.trim()) return false;
+  try {
+    new URL(value);
+    return false;
+  } catch {
+    return !value.startsWith('data:');
+  }
+}
+
+function isOutsideDocumentFolder(
+  absoluteImagePath: string,
+  documentPath: string,
+): boolean {
+  const relative = toRelativePath(absoluteImagePath, documentPath);
+  return relative === absoluteImagePath;
+}
+
+function toRelativePath(
+  absoluteImagePath: string,
+  documentPath: string,
+): string {
+  const sep = documentPath.includes('\\') ? '\\' : '/';
+  const docDir =
+    documentPath.substring(
+      0,
+      Math.max(
+        documentPath.lastIndexOf('/'),
+        documentPath.lastIndexOf('\\'),
+      ),
+    ) + sep;
+
+  const normalizedImage = absoluteImagePath.replace(/\\/g, '/');
+  const normalizedDir = docDir.replace(/\\/g, '/');
+
+  if (normalizedImage.startsWith(normalizedDir)) {
+    return normalizedImage.substring(normalizedDir.length);
+  }
+
+  return absoluteImagePath;
+}
+
 export function InsertAssetDialog({
   dialog,
+  documentPath,
   onClose,
   onInsert,
 }: InsertAssetDialogProps) {
@@ -45,6 +89,7 @@ export function InsertAssetDialog({
     <InsertAssetDialogContent
       key={`${dialog.type}:${dialog.initialText}`}
       dialog={dialog}
+      documentPath={documentPath}
       onClose={onClose}
       onInsert={onInsert}
     />
@@ -53,12 +98,14 @@ export function InsertAssetDialog({
 
 type InsertAssetDialogContentProps = {
   dialog: Exclude<InsertAssetDialogState, null>;
+  documentPath?: string | null;
   onClose: () => void;
   onInsert: (payload: InsertAssetPayload) => void;
 };
 
 function InsertAssetDialogContent({
   dialog,
+  documentPath,
   onClose,
   onInsert,
 }: InsertAssetDialogContentProps) {
@@ -87,12 +134,33 @@ function InsertAssetDialogContent({
   }, [onClose]);
 
   const isLink = dialog.type === 'link';
+  const isImage = dialog.type === 'image';
   const title = isLink ? t('insertAsset.insertLink') : t('insertAsset.insertImage');
   const textLabel = isLink ? t('insertAsset.linkText') : t('insertAsset.altText');
   const textPlaceholder = isLink
     ? t('insertAsset.linkTextPlaceholder')
     : t('insertAsset.altTextPlaceholder');
   const submitLabel = isLink ? t('insertAsset.insertLink') : t('insertAsset.insertImage');
+  const urlLabel = isImage ? t('insertAsset.imagePathOrUrl') : t('insertAsset.url');
+
+  const imageWarning = useMemo(() => {
+    if (!isImage || !url.trim()) return null;
+    if (!isLocalPath(url)) return null;
+    if (!documentPath) return t('insertAsset.warnUnsaved');
+    if (isOutsideDocumentFolder(url, documentPath)) return t('insertAsset.warnOutsideFolder');
+    return null;
+  }, [isImage, url, documentPath, t]);
+
+  async function handleBrowse() {
+    const picked = await window.marky.pickImage();
+    if (!picked) return;
+
+    if (documentPath) {
+      setUrl(toRelativePath(picked, documentPath));
+    } else {
+      setUrl(picked);
+    }
+  }
 
   function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -143,21 +211,46 @@ function InsertAssetDialogContent({
         <form className="space-y-4 px-5 py-5" onSubmit={handleSubmit}>
           <div>
             <label className={labelClass} htmlFor="insert-asset-url">
-              {t('insertAsset.url')}
+              {urlLabel}
             </label>
-            <input
-              id="insert-asset-url"
-              ref={urlInputRef}
-              type="url"
-              className={inputClass}
-              value={url}
-              onChange={(event) => setUrl(event.target.value)}
-              placeholder={
-                isLink
-                  ? t('insertAsset.linkPlaceholder')
-                  : t('insertAsset.imagePlaceholder')
-              }
-            />
+            <div className={isImage ? 'flex gap-2' : ''}>
+              <input
+                id="insert-asset-url"
+                ref={urlInputRef}
+                type={isLink ? 'url' : 'text'}
+                className={inputClass}
+                value={url}
+                onChange={(event) => setUrl(event.target.value)}
+                placeholder={
+                  isLink
+                    ? t('insertAsset.linkPlaceholder')
+                    : t('insertAsset.imagePlaceholder')
+                }
+              />
+              {isImage && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="shrink-0"
+                  onClick={handleBrowse}
+                  aria-label={t('insertAsset.browse')}
+                >
+                  <FolderOpen className="mr-1.5 size-4" />
+                  {t('insertAsset.browse')}
+                </Button>
+              )}
+            </div>
+            {isImage && (
+              <p className="mt-1.5 text-xs text-muted-foreground">
+                {t('insertAsset.localImageHint')}
+              </p>
+            )}
+            {imageWarning && (
+              <p className="mt-1.5 flex items-start gap-1.5 text-xs text-amber-600 dark:text-amber-400">
+                <TriangleAlert className="mt-px size-3.5 shrink-0" />
+                <span>{imageWarning}</span>
+              </p>
+            )}
           </div>
 
           <div>

--- a/src/renderer/src/features/preview/components/preview-pane.tsx
+++ b/src/renderer/src/features/preview/components/preview-pane.tsx
@@ -6,6 +6,7 @@ import { renderMarkdown } from '../lib/markdown';
 
 type PreviewPaneProps = {
   markdown: string;
+  documentPath?: string | null;
 };
 
 type MermaidTheme = 'light' | 'dark';
@@ -74,7 +75,7 @@ function ensureMermaid(
 const mermaidCache = new Map<string, string>();
 let mermaidSeq = 0;
 
-export function PreviewPane({ markdown }: PreviewPaneProps) {
+export function PreviewPane({ markdown, documentPath }: PreviewPaneProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const theme = useSettingsStore((state) => state.settings.theme);
   const previewFontFamily = useSettingsStore(
@@ -83,7 +84,7 @@ export function PreviewPane({ markdown }: PreviewPaneProps) {
   const previewFontSize = useSettingsStore(
     (state) => state.settings.previewFontSize,
   );
-  const html = useMemo(() => renderMarkdown(markdown), [markdown]);
+  const html = useMemo(() => renderMarkdown(markdown, documentPath), [markdown, documentPath]);
 
   useEffect(() => {
     ensureMermaid(theme, previewFontFamily, previewFontSize);

--- a/src/renderer/src/features/preview/components/preview-pane.tsx
+++ b/src/renderer/src/features/preview/components/preview-pane.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef } from 'react';
 import mermaid from 'mermaid';
 import { toPreviewFontFamilyCss } from '@renderer/features/settings/lib/font-options';
+import { useTranslation } from '@renderer/i18n';
 import { useSettingsStore } from '@renderer/features/settings/store';
 import { renderMarkdown } from '../lib/markdown';
 
@@ -75,8 +76,16 @@ function ensureMermaid(
 const mermaidCache = new Map<string, string>();
 let mermaidSeq = 0;
 
+function createImagePlaceholder(message: string): HTMLElement {
+  const placeholder = document.createElement('div');
+  placeholder.className = 'image-placeholder';
+  placeholder.textContent = message;
+  return placeholder;
+}
+
 export function PreviewPane({ markdown, documentPath }: PreviewPaneProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const { t } = useTranslation();
   const theme = useSettingsStore((state) => state.settings.theme);
   const previewFontFamily = useSettingsStore(
     (state) => state.settings.previewFontFamily,
@@ -95,6 +104,28 @@ export function PreviewPane({ markdown, documentPath }: PreviewPaneProps) {
     container.innerHTML = html;
 
     let cancelled = false;
+
+    const images = Array.from(container.querySelectorAll<HTMLImageElement>('img'));
+
+    for (const img of images) {
+      const src = img.getAttribute('src') ?? '';
+      const isLocalAsset = src.startsWith('local-asset://');
+      const isUnresolved = !src.startsWith('http://') &&
+        !src.startsWith('https://') &&
+        !src.startsWith('data:') &&
+        !isLocalAsset &&
+        src.length > 0;
+
+      if (isUnresolved || isLocalAsset) {
+        img.addEventListener('error', () => {
+          if (cancelled) return;
+          const message = isUnresolved
+            ? t('preview.imageUnsaved')
+            : t('preview.imageOutsideFolder');
+          img.replaceWith(createImagePlaceholder(message));
+        }, { once: true });
+      }
+    }
 
     const blocks = Array.from(
       container.querySelectorAll<HTMLElement>('pre > code.language-mermaid'),
@@ -140,7 +171,7 @@ export function PreviewPane({ markdown, documentPath }: PreviewPaneProps) {
     return () => {
       cancelled = true;
     };
-  }, [html, previewFontFamily, previewFontSize, theme]);
+  }, [html, previewFontFamily, previewFontSize, theme, t]);
 
   return <div ref={containerRef} className="preview-prose dark:prose-invert" />;
 }

--- a/src/renderer/src/features/preview/lib/markdown.ts
+++ b/src/renderer/src/features/preview/lib/markdown.ts
@@ -4,14 +4,56 @@ import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
 import remarkRehype from 'remark-rehype';
 import rehypeStringify from 'rehype-stringify';
+import type { Root } from 'hast';
+import { visit } from 'unist-util-visit';
 
-const processor = unified()
-  .use(remarkParse)
-  .use(remarkGfm)
-  .use(remarkBreaks)
-  .use(remarkRehype)
-  .use(rehypeStringify);
+function isRelativePath(src: string): boolean {
+  try {
+    new URL(src);
+    return false;
+  } catch {
+    return !src.startsWith('data:');
+  }
+}
 
-export function renderMarkdown(markdown: string) {
-  return processor.processSync(markdown).toString();
+function toLocalAssetUrl(baseDir: string, relativePath: string): string {
+  return `local-asset://asset?base=${encodeURIComponent(baseDir)}&path=${encodeURIComponent(relativePath)}`;
+}
+
+function rehypeResolveLocalImages(baseDir: string) {
+  return () => (tree: Root) => {
+    visit(tree, 'element', (node) => {
+      if (node.tagName === 'img' && typeof node.properties.src === 'string') {
+        const src = node.properties.src;
+        if (isRelativePath(src)) {
+          node.properties.src = toLocalAssetUrl(baseDir, src);
+        }
+      }
+    });
+  };
+}
+
+function createProcessor(baseDir?: string) {
+  const pipeline = unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .use(remarkBreaks)
+    .use(remarkRehype)
+
+  if (baseDir) {
+    pipeline.use(rehypeResolveLocalImages(baseDir));
+  }
+
+  return pipeline.use(rehypeStringify);
+}
+
+const defaultProcessor = createProcessor();
+
+export function renderMarkdown(markdown: string, documentPath?: string | null) {
+  if (documentPath) {
+    const lastSep = Math.max(documentPath.lastIndexOf('/'), documentPath.lastIndexOf('\\'));
+    const baseDir = documentPath.substring(0, lastSep);
+    return createProcessor(baseDir).processSync(markdown).toString();
+  }
+  return defaultProcessor.processSync(markdown).toString();
 }

--- a/src/renderer/src/i18n/en.ts
+++ b/src/renderer/src/i18n/en.ts
@@ -127,6 +127,11 @@ export const en: TranslationKeys = {
   'insertAsset.linkTextPlaceholder': 'Text shown in the document',
   'insertAsset.altTextPlaceholder': 'Describe the image',
   'insertAsset.cancel': 'Cancel',
+  'insertAsset.browse': 'Browse',
+  'insertAsset.imagePathOrUrl': 'Path or URL',
+  'insertAsset.localImageHint': 'Use a URL or browse for a local image. Local images are resolved relative to the document folder.',
+  'insertAsset.warnUnsaved': 'Save the document first so local images can be displayed.',
+  'insertAsset.warnOutsideFolder': 'This image is outside the document folder and won\'t be displayed in the preview.',
 
   // Document status
   'status.words': '{count} words',

--- a/src/renderer/src/i18n/en.ts
+++ b/src/renderer/src/i18n/en.ts
@@ -133,6 +133,10 @@ export const en: TranslationKeys = {
   'insertAsset.warnUnsaved': 'Save the document first so local images can be displayed.',
   'insertAsset.warnOutsideFolder': 'This image is outside the document folder and won\'t be displayed in the preview.',
 
+  // Preview image placeholders
+  'preview.imageUnsaved': 'Local image — save the document to display it.',
+  'preview.imageOutsideFolder': 'Image outside the document folder — can\'t be displayed.',
+
   // Document status
   'status.words': '{count} words',
   'status.characters': '{count} characters',

--- a/src/renderer/src/i18n/es.ts
+++ b/src/renderer/src/i18n/es.ts
@@ -127,6 +127,11 @@ export const es: TranslationKeys = {
   'insertAsset.linkTextPlaceholder': 'Texto mostrado en el documento',
   'insertAsset.altTextPlaceholder': 'Describe la imagen',
   'insertAsset.cancel': 'Cancelar',
+  'insertAsset.browse': 'Explorar',
+  'insertAsset.imagePathOrUrl': 'Ruta o URL',
+  'insertAsset.localImageHint': 'Usa una URL o busca una imagen local. Las imágenes locales se resuelven en relación a la carpeta del documento.',
+  'insertAsset.warnUnsaved': 'Guarda el documento primero para que las imágenes locales se puedan mostrar.',
+  'insertAsset.warnOutsideFolder': 'Esta imagen está fuera de la carpeta del documento y no se mostrará en la vista previa.',
 
   // Estado del documento
   'status.words': '{count} palabras',

--- a/src/renderer/src/i18n/es.ts
+++ b/src/renderer/src/i18n/es.ts
@@ -133,6 +133,10 @@ export const es: TranslationKeys = {
   'insertAsset.warnUnsaved': 'Guarda el documento primero para que las imágenes locales se puedan mostrar.',
   'insertAsset.warnOutsideFolder': 'Esta imagen está fuera de la carpeta del documento y no se mostrará en la vista previa.',
 
+  // Placeholders de imagen en la vista previa
+  'preview.imageUnsaved': 'Imagen local — guarda el documento para mostrarla.',
+  'preview.imageOutsideFolder': 'Imagen fuera de la carpeta del documento — no se puede mostrar.',
+
   // Estado del documento
   'status.words': '{count} palabras',
   'status.characters': '{count} caracteres',

--- a/src/renderer/src/i18n/pt-BR.ts
+++ b/src/renderer/src/i18n/pt-BR.ts
@@ -133,6 +133,10 @@ export const ptBR: TranslationKeys = {
   'insertAsset.warnUnsaved': 'Salve o documento primeiro para que imagens locais possam ser exibidas.',
   'insertAsset.warnOutsideFolder': 'Esta imagem está fora da pasta do documento e não será exibida na pré-visualização.',
 
+  // Placeholders de imagem na pré-visualização
+  'preview.imageUnsaved': 'Imagem local — salve o documento para exibi-la.',
+  'preview.imageOutsideFolder': 'Imagem fora da pasta do documento — não pode ser exibida.',
+
   // Status do documento
   'status.words': '{count} palavras',
   'status.characters': '{count} caracteres',

--- a/src/renderer/src/i18n/pt-BR.ts
+++ b/src/renderer/src/i18n/pt-BR.ts
@@ -127,6 +127,11 @@ export const ptBR: TranslationKeys = {
   'insertAsset.linkTextPlaceholder': 'Texto exibido no documento',
   'insertAsset.altTextPlaceholder': 'Descreva a imagem',
   'insertAsset.cancel': 'Cancelar',
+  'insertAsset.browse': 'Procurar',
+  'insertAsset.imagePathOrUrl': 'Caminho ou URL',
+  'insertAsset.localImageHint': 'Use uma URL ou procure uma imagem local. Imagens locais são resolvidas em relação à pasta do documento.',
+  'insertAsset.warnUnsaved': 'Salve o documento primeiro para que imagens locais possam ser exibidas.',
+  'insertAsset.warnOutsideFolder': 'Esta imagem está fora da pasta do documento e não será exibida na pré-visualização.',
 
   // Status do documento
   'status.words': '{count} palavras',

--- a/src/renderer/src/i18n/types.ts
+++ b/src/renderer/src/i18n/types.ts
@@ -120,6 +120,11 @@ export type TranslationKeys = {
   'insertAsset.linkTextPlaceholder': string;
   'insertAsset.altTextPlaceholder': string;
   'insertAsset.cancel': string;
+  'insertAsset.browse': string;
+  'insertAsset.imagePathOrUrl': string;
+  'insertAsset.localImageHint': string;
+  'insertAsset.warnUnsaved': string;
+  'insertAsset.warnOutsideFolder': string;
 
   // ── Document status ──────────────────────────────────────────────
   'status.words': string;

--- a/src/renderer/src/i18n/types.ts
+++ b/src/renderer/src/i18n/types.ts
@@ -126,6 +126,10 @@ export type TranslationKeys = {
   'insertAsset.warnUnsaved': string;
   'insertAsset.warnOutsideFolder': string;
 
+  // ── Preview image placeholders ───────────────────────────────────
+  'preview.imageUnsaved': string;
+  'preview.imageOutsideFolder': string;
+
   // ── Document status ──────────────────────────────────────────────
   'status.words': string;
   'status.characters': string;

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -250,6 +250,17 @@
     @apply mt-3 block rounded-xl bg-destructive/10 px-3 py-2 text-sm text-destructive;
   }
 
+  .image-placeholder {
+    @apply my-4 flex items-center gap-2 rounded-xl border border-amber-300/40 bg-amber-50 px-4 py-3 text-sm text-amber-700 dark:border-amber-500/20 dark:bg-amber-950/30 dark:text-amber-400;
+  }
+
+  .image-placeholder::before {
+    content: '';
+    @apply block size-5 shrink-0;
+    background: currentColor;
+    mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect width='18' height='18' x='3' y='3' rx='2' ry='2'/%3E%3Ccircle cx='9' cy='9' r='2'/%3E%3Cpath d='m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21'/%3E%3C/svg%3E") center / contain no-repeat;
+  }
+
   .notice-pill {
     @apply rounded-full px-3 py-1 text-xs font-medium;
   }

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -24,6 +24,7 @@ export const ipcChannels = {
   settingsSet: 'settings:set',
   getLocale: 'locale:get',
   updateMenuLanguage: 'menu:update-language',
+  pickImage: 'document:pick-image',
 } as const;
 
 export type MarkyApi = {
@@ -42,4 +43,5 @@ export type MarkyApi = {
   setSettings: (settings: AppSettings) => Promise<void>;
   getLocale: () => Promise<string>;
   updateMenuLanguage: (locale: Locale) => Promise<void>;
+  pickImage: () => Promise<string | null>;
 };


### PR DESCRIPTION
## Summary

- Register a custom `local-asset://` protocol in the main process to serve local files from the document's directory, with path traversal protection and file existence checks
- Add a rehype plugin to the markdown pipeline that rewrites relative image paths to `local-asset://` URLs when the document is saved
- Add a "Browse" button to the insert image dialog that opens a native file picker filtered to image formats, automatically converting the picked path to a relative path from the document folder
- Show contextual amber warnings in the dialog when inserting a local image on an unsaved document or an image outside the document folder
- Replace broken local images in the preview with styled placeholders explaining why the image can't be displayed
- Add all new UI strings to en, pt-BR, and es translations

Closes #12

## Test plan

- [x] Open a saved `.md` file that references a local image with a relative path (e.g. `![alt](assets/image.png)`) and verify it renders in the preview
- [x] Open the insert image dialog and use the "Browse" button to pick a local image — verify the path is inserted as a relative path
- [x] Pick an image outside the document folder and verify the amber warning appears in the dialog
- [x] Open an unsaved document, insert a local image path, and verify the "save first" warning appears in the dialog
- [x] Verify unsaved documents show the "save to display" placeholder in the preview instead of a broken image
- [x] Try a path traversal like `![x](../../etc/passwd)` and verify it returns 403 / shows the "outside folder" placeholder
- [x] Verify web URLs (`https://...`) and data URIs still work normally
- [x] Switch language to pt-BR and es and verify all new strings are translated
- [x] Run `npm run typecheck` and `npm run lint` with no new errors