### PR TITLE
fix: replace renderer reload with file-reload-from-disk action

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -10,6 +10,7 @@ type MenuLabels = {
   file: string;
   new: string;
   open: string;
+  reload: string;
   save: string;
   saveAs: string;
   exportHtml: string;
@@ -25,6 +26,7 @@ const labels: Record<Locale, MenuLabels> = {
     file: 'File',
     new: 'New',
     open: 'Open...',
+    reload: 'Reload',
     save: 'Save',
     saveAs: 'Save As...',
     exportHtml: 'Export HTML...',
@@ -38,6 +40,7 @@ const labels: Record<Locale, MenuLabels> = {
     file: 'Arquivo',
     new: 'Novo',
     open: 'Abrir...',
+    reload: 'Recarregar',
     save: 'Salvar',
     saveAs: 'Salvar como...',
     exportHtml: 'Exportar HTML...',
@@ -51,6 +54,7 @@ const labels: Record<Locale, MenuLabels> = {
     file: 'Archivo',
     new: 'Nuevo',
     open: 'Abrir...',
+    reload: 'Recargar',
     save: 'Guardar',
     saveAs: 'Guardar como...',
     exportHtml: 'Exportar HTML...',
@@ -83,6 +87,11 @@ export function createAppMenu(window: BrowserWindow, locale: Locale = 'en') {
           label: l.open,
           accelerator: 'CmdOrCtrl+O',
           click: () => sendAction(window, 'file:open'),
+        },
+        {
+          label: l.reload,
+          accelerator: 'CmdOrCtrl+R',
+          click: () => sendAction(window, 'file:reload'),
         },
         { type: 'separator' },
         {
@@ -133,7 +142,6 @@ export function createAppMenu(window: BrowserWindow, locale: Locale = 'en') {
           {
             label: 'Developer',
             submenu: [
-              { role: 'reload' as const, accelerator: 'CmdOrCtrl+R' },
               {
                 role: 'forceReload' as const,
                 accelerator: 'CmdOrCtrl+Shift+R',

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -143,8 +143,11 @@ export function createAppMenu(window: BrowserWindow, locale: Locale = 'en') {
             label: 'Developer',
             submenu: [
               {
+                // Deliberately not on any +R combo: CmdOrCtrl+R is now
+                // reload-from-disk, and a neighbouring shortcut that instead
+                // restarts the renderer and wipes state is a trap.
                 role: 'forceReload' as const,
-                accelerator: 'CmdOrCtrl+Shift+R',
+                accelerator: 'CmdOrCtrl+Shift+F5',
               },
               {
                 role: 'toggleDevTools' as const,

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -148,6 +148,7 @@ export function App() {
             recentFiles={recentFiles}
             onNew={() => void handleMenuAction('file:new')}
             onOpen={() => void handleMenuAction('file:open')}
+            onReload={() => void handleMenuAction('file:reload')}
             onOpenRecent={(path) => void openRecentFile(path)}
             onRemoveRecent={removeRecentFile}
             onClearRecent={clearRecentFiles}

--- a/src/renderer/src/features/help/components/help-dialog.tsx
+++ b/src/renderer/src/features/help/components/help-dialog.tsx
@@ -54,6 +54,7 @@ const editorShortcuts: ShortcutEntry[] = [
 const fileShortcuts: ShortcutEntry[] = [
   { keys: `${mod}+N`, labelKey: 'help.newDocument' },
   { keys: `${mod}+O`, labelKey: 'help.openFile' },
+  { keys: `${mod}+R`, labelKey: 'help.reload' },
   { keys: `${mod}+S`, labelKey: 'help.save' },
   { keys: `${mod}+Shift+S`, labelKey: 'help.saveCopy' },
   { keys: `${mod}+Alt+H`, labelKey: 'help.exportHtml' },

--- a/src/renderer/src/features/titlebar/components/file-actions.tsx
+++ b/src/renderer/src/features/titlebar/components/file-actions.tsx
@@ -5,6 +5,7 @@ import {
   Clock,
   FileDown,
   FileOutput,
+  RefreshCw,
   Save,
   Trash2,
   X,
@@ -12,9 +13,28 @@ import {
 import { Button } from '@renderer/components/ui/button';
 import { cn } from '@renderer/lib/utils';
 import { basename, dirname } from '@renderer/lib/paths';
+import { modKey } from '@renderer/lib/platform';
 import { noDrag } from '@renderer/lib/window-region';
 import { useDismissOnOutside } from '@renderer/lib/use-dismiss-on-outside';
 import { useTranslation } from '@renderer/i18n';
+
+export function ReloadButton({ onReload }: { onReload: () => void }) {
+  const { t } = useTranslation();
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className="rounded-full"
+      style={noDrag}
+      onClick={onReload}
+      aria-label={t('titlebar.reload')}
+      title={`${t('titlebar.reload')} (${modKey}+R)`}
+    >
+      <RefreshCw className="size-4" />
+    </Button>
+  );
+}
 
 export function ExportDropdown({
   onExportPdf,

--- a/src/renderer/src/features/titlebar/components/title-bar.tsx
+++ b/src/renderer/src/features/titlebar/components/title-bar.tsx
@@ -6,6 +6,7 @@ import {
   Minus,
   PanelLeft,
   PanelRight,
+  RefreshCw,
   ScanSearch,
   Settings,
   Square,
@@ -31,6 +32,7 @@ interface TitleBarProps {
   recentFiles: string[];
   onNew: () => void;
   onOpen: () => void;
+  onReload: () => void;
   onOpenRecent: (path: string) => void;
   onRemoveRecent: (path: string) => void;
   onClearRecent: () => void;
@@ -61,6 +63,7 @@ export function TitleBar({
   recentFiles,
   onNew,
   onOpen,
+  onReload,
   onOpenRecent,
   onRemoveRecent,
   onClearRecent,
@@ -187,6 +190,16 @@ export function TitleBar({
         onRemoveRecent={onRemoveRecent}
         onClearRecent={onClearRecent}
       />
+      <Button
+        variant="ghost"
+        size="icon"
+        className="rounded-full"
+        onClick={onReload}
+        aria-label={t('titlebar.reload')}
+        title={`${t('titlebar.reload')} (Ctrl+R)`}
+      >
+        <RefreshCw className="size-4" />
+      </Button>
       <SplitSaveButton onSave={onSave} onSaveAs={onSaveAs} />
       <ExportDropdown onExportPdf={onExportPdf} onExportHtml={onExportHtml} />
       <Button

--- a/src/renderer/src/features/titlebar/components/title-bar.tsx
+++ b/src/renderer/src/features/titlebar/components/title-bar.tsx
@@ -6,7 +6,6 @@ import {
   Minus,
   PanelLeft,
   PanelRight,
-  RefreshCw,
   ScanSearch,
   Settings,
   Square,
@@ -20,6 +19,7 @@ import type { TranslationKeys } from '@renderer/i18n';
 import type { ViewMode } from '@shared/types';
 import {
   ExportDropdown,
+  ReloadButton,
   SplitOpenButton,
   SplitSaveButton,
 } from './file-actions';
@@ -190,16 +190,7 @@ export function TitleBar({
         onRemoveRecent={onRemoveRecent}
         onClearRecent={onClearRecent}
       />
-      <Button
-        variant="ghost"
-        size="icon"
-        className="rounded-full"
-        onClick={onReload}
-        aria-label={t('titlebar.reload')}
-        title={`${t('titlebar.reload')} (Ctrl+R)`}
-      >
-        <RefreshCw className="size-4" />
-      </Button>
+      <ReloadButton onReload={onReload} />
       <SplitSaveButton onSave={onSave} onSaveAs={onSaveAs} />
       <ExportDropdown onExportPdf={onExportPdf} onExportHtml={onExportHtml} />
       <Button

--- a/src/renderer/src/features/workspace/hooks/use-document-actions.ts
+++ b/src/renderer/src/features/workspace/hooks/use-document-actions.ts
@@ -1,6 +1,10 @@
 import { useCallback, useEffect } from 'react';
 import { buildExportHtml } from '@renderer/features/export/lib/build-export-html';
-import { useWorkspaceStore } from '@renderer/features/workspace/store';
+import { reloadDocument } from '@renderer/features/workspace/lib/reload-document';
+import {
+  selectIsDirty,
+  useWorkspaceStore,
+} from '@renderer/features/workspace/store';
 import { useSettingsStore } from '@renderer/features/settings/store';
 import { useTranslation } from '@renderer/i18n';
 import type { MenuAction } from '@shared/types';
@@ -14,6 +18,7 @@ export function useDocumentActions(
 ) {
   const { t } = useTranslation();
   const activeDocument = useWorkspaceStore((state) => state.document);
+  const isDirty = useWorkspaceStore(selectIsDirty);
   const setDocument = useWorkspaceStore((state) => state.setDocument);
   const createUntitledDocument = useWorkspaceStore(
     (state) => state.createUntitledDocument,
@@ -129,16 +134,25 @@ export function useDocumentActions(
           return;
         }
         case 'file:reload': {
-          if (!activeDocument.path) {
-            setNotice(t('notice.nothingToReload'), 'info');
-            return;
-          }
-          const reloaded = await window.marky.openDocumentFromPath(
-            activeDocument.path,
-          );
-          if (reloaded) {
-            setDocument(reloaded);
-            setNotice(t('notice.reloaded'), 'success');
+          const outcome = await reloadDocument({
+            path: activeDocument.path,
+            isDirty,
+            readDocument: window.marky.openDocumentFromPath,
+          });
+          switch (outcome.status) {
+            case 'nothing-to-reload':
+              setNotice(t('notice.nothingToReload'), 'info');
+              return;
+            case 'blocked-unsaved':
+              setNotice(t('notice.reloadBlockedUnsaved'), 'info');
+              return;
+            case 'file-not-found':
+              setNotice(t('notice.reloadFileNotFound'), 'info');
+              return;
+            case 'reloaded':
+              setDocument(outcome.document);
+              setNotice(t('notice.reloaded'), 'success');
+              return;
           }
           return;
         }
@@ -163,6 +177,7 @@ export function useDocumentActions(
       addRecentFile,
       createUntitledDocument,
       exportDocument,
+      isDirty,
       saveDocument,
       setDocument,
       setNotice,

--- a/src/renderer/src/features/workspace/hooks/use-document-actions.ts
+++ b/src/renderer/src/features/workspace/hooks/use-document-actions.ts
@@ -128,6 +128,20 @@ export function useDocumentActions(
           }
           return;
         }
+        case 'file:reload': {
+          if (!activeDocument.path) {
+            setNotice(t('notice.nothingToReload'), 'info');
+            return;
+          }
+          const reloaded = await window.marky.openDocumentFromPath(
+            activeDocument.path,
+          );
+          if (reloaded) {
+            setDocument(reloaded);
+            setNotice(t('notice.reloaded'), 'success');
+          }
+          return;
+        }
         case 'file:save':
           return saveDocument('save');
         case 'file:save-as':

--- a/src/renderer/src/features/workspace/lib/reload-document.ts
+++ b/src/renderer/src/features/workspace/lib/reload-document.ts
@@ -1,0 +1,40 @@
+import type { DocumentHandle } from '@shared/types';
+
+export type ReloadOutcome =
+  | { status: 'nothing-to-reload' }
+  | { status: 'blocked-unsaved' }
+  | { status: 'file-not-found' }
+  | { status: 'reloaded'; document: DocumentHandle };
+
+/**
+ * Decides what reloading the open document from disk should do.
+ *
+ * Kept free of React and IPC so every branch is directly testable: the caller
+ * injects the read, and the caller maps the outcome onto a user-facing notice.
+ */
+export async function reloadDocument({
+  path,
+  isDirty,
+  readDocument,
+}: {
+  path: string | null;
+  isDirty: boolean;
+  readDocument: (path: string) => Promise<DocumentHandle | null>;
+}): Promise<ReloadOutcome> {
+  if (!path) {
+    return { status: 'nothing-to-reload' };
+  }
+
+  // Reloading replaces the buffer outright, so unsaved edits would be lost
+  // with no undo. Refuse rather than destroy them.
+  if (isDirty) {
+    return { status: 'blocked-unsaved' };
+  }
+
+  const document = await readDocument(path);
+  if (!document) {
+    return { status: 'file-not-found' };
+  }
+
+  return { status: 'reloaded', document };
+}

--- a/src/renderer/src/i18n/en.ts
+++ b/src/renderer/src/i18n/en.ts
@@ -46,6 +46,7 @@ export const en: TranslationKeys = {
   // Title bar
   'titlebar.new': 'New document',
   'titlebar.open': 'Open',
+  'titlebar.reload': 'Reload',
   'titlebar.save': 'Save',
   'titlebar.saveCopy': 'Save a copy',
   'titlebar.export': 'Export',
@@ -169,6 +170,8 @@ export const en: TranslationKeys = {
   'notice.freshDraft': 'Started a fresh draft.',
   'notice.opened': 'Opened {name}.',
   'notice.fileNotFound': 'File not found — removed from recent list.',
+  'notice.reloaded': 'File reloaded from disk.',
+  'notice.nothingToReload': 'No saved file is open — nothing to reload.',
 
   // Shared controls
   'combobox.noMatches': 'No matches',

--- a/src/renderer/src/i18n/en.ts
+++ b/src/renderer/src/i18n/en.ts
@@ -107,6 +107,7 @@ export const en: TranslationKeys = {
   'help.saveCopy': 'Save a copy',
   'help.exportHtml': 'Export HTML',
   'help.exportPdf': 'Export PDF',
+  'help.reload': 'Reload from disk',
   'help.editorOnly': 'Editor only',
   'help.splitView': 'Split view',
   'help.previewOnly': 'Preview only',
@@ -172,6 +173,9 @@ export const en: TranslationKeys = {
   'notice.fileNotFound': 'File not found — removed from recent list.',
   'notice.reloaded': 'File reloaded from disk.',
   'notice.nothingToReload': 'No saved file is open — nothing to reload.',
+  'notice.reloadBlockedUnsaved':
+    'Unsaved changes — save or undo them before reloading from disk.',
+  'notice.reloadFileNotFound': 'File no longer exists on disk.',
 
   // Shared controls
   'combobox.noMatches': 'No matches',

--- a/src/renderer/src/i18n/es.ts
+++ b/src/renderer/src/i18n/es.ts
@@ -46,6 +46,7 @@ export const es: TranslationKeys = {
   // Barra de título
   'titlebar.new': 'Nuevo documento',
   'titlebar.open': 'Abrir',
+  'titlebar.reload': 'Recargar',
   'titlebar.save': 'Guardar',
   'titlebar.saveCopy': 'Guardar una copia',
   'titlebar.export': 'Exportar',
@@ -170,6 +171,9 @@ export const es: TranslationKeys = {
   'notice.opened': '{name} abierto.',
   'notice.fileNotFound':
     'Archivo no encontrado — eliminado de la lista de recientes.',
+  'notice.reloaded': 'Archivo recargado desde el disco.',
+  'notice.nothingToReload':
+    'No hay ningún archivo guardado abierto — nada que recargar.',
 
   // Controles compartidos
   'combobox.noMatches': 'Sin coincidencias',

--- a/src/renderer/src/i18n/es.ts
+++ b/src/renderer/src/i18n/es.ts
@@ -107,6 +107,7 @@ export const es: TranslationKeys = {
   'help.saveCopy': 'Guardar una copia',
   'help.exportHtml': 'Exportar HTML',
   'help.exportPdf': 'Exportar PDF',
+  'help.reload': 'Recargar desde el disco',
   'help.editorOnly': 'Solo editor',
   'help.splitView': 'Vista dividida',
   'help.previewOnly': 'Solo vista previa',
@@ -174,6 +175,9 @@ export const es: TranslationKeys = {
   'notice.reloaded': 'Archivo recargado desde el disco.',
   'notice.nothingToReload':
     'No hay ningún archivo guardado abierto — nada que recargar.',
+  'notice.reloadBlockedUnsaved':
+    'Hay cambios sin guardar — guárdalos o deshazlos antes de recargar desde el disco.',
+  'notice.reloadFileNotFound': 'El archivo ya no existe en el disco.',
 
   // Controles compartidos
   'combobox.noMatches': 'Sin coincidencias',

--- a/src/renderer/src/i18n/pt-BR.ts
+++ b/src/renderer/src/i18n/pt-BR.ts
@@ -46,6 +46,7 @@ export const ptBR: TranslationKeys = {
   // Barra de título
   'titlebar.new': 'Novo documento',
   'titlebar.open': 'Abrir',
+  'titlebar.reload': 'Recarregar',
   'titlebar.save': 'Salvar',
   'titlebar.saveCopy': 'Salvar uma cópia',
   'titlebar.export': 'Exportar',
@@ -170,6 +171,9 @@ export const ptBR: TranslationKeys = {
   'notice.opened': '{name} aberto.',
   'notice.fileNotFound':
     'Arquivo não encontrado — removido da lista de recentes.',
+  'notice.reloaded': 'Arquivo recarregado do disco.',
+  'notice.nothingToReload':
+    'Nenhum arquivo salvo está aberto — nada para recarregar.',
 
   // Controles compartilhados
   'combobox.noMatches': 'Nenhum resultado',

--- a/src/renderer/src/i18n/pt-BR.ts
+++ b/src/renderer/src/i18n/pt-BR.ts
@@ -107,6 +107,7 @@ export const ptBR: TranslationKeys = {
   'help.saveCopy': 'Salvar uma cópia',
   'help.exportHtml': 'Exportar HTML',
   'help.exportPdf': 'Exportar PDF',
+  'help.reload': 'Recarregar do disco',
   'help.editorOnly': 'Somente editor',
   'help.splitView': 'Visualização dividida',
   'help.previewOnly': 'Somente visualização',
@@ -174,6 +175,9 @@ export const ptBR: TranslationKeys = {
   'notice.reloaded': 'Arquivo recarregado do disco.',
   'notice.nothingToReload':
     'Nenhum arquivo salvo está aberto — nada para recarregar.',
+  'notice.reloadBlockedUnsaved':
+    'Há alterações não salvas — salve-as ou desfaça-as antes de recarregar do disco.',
+  'notice.reloadFileNotFound': 'O arquivo não existe mais no disco.',
 
   // Controles compartilhados
   'combobox.noMatches': 'Nenhum resultado',

--- a/src/renderer/src/i18n/types.ts
+++ b/src/renderer/src/i18n/types.ts
@@ -38,6 +38,7 @@ export type TranslationKeys = {
   'titlebar.removeRecent': string;
   'titlebar.new': string;
   'titlebar.open': string;
+  'titlebar.reload': string;
   'titlebar.save': string;
   'titlebar.saveCopy': string;
   'titlebar.export': string;
@@ -156,6 +157,8 @@ export type TranslationKeys = {
   'notice.freshDraft': string;
   'notice.opened': string;
   'notice.fileNotFound': string;
+  'notice.reloaded': string;
+  'notice.nothingToReload': string;
 
   // Shared controls
   'combobox.noMatches': string;

--- a/src/renderer/src/i18n/types.ts
+++ b/src/renderer/src/i18n/types.ts
@@ -98,6 +98,7 @@ export type TranslationKeys = {
   'help.saveCopy': string;
   'help.exportHtml': string;
   'help.exportPdf': string;
+  'help.reload': string;
   'help.editorOnly': string;
   'help.splitView': string;
   'help.previewOnly': string;
@@ -159,6 +160,8 @@ export type TranslationKeys = {
   'notice.fileNotFound': string;
   'notice.reloaded': string;
   'notice.nothingToReload': string;
+  'notice.reloadBlockedUnsaved': string;
+  'notice.reloadFileNotFound': string;
 
   // Shared controls
   'combobox.noMatches': string;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -68,6 +68,7 @@ export type SaveResult = {
 export type MenuAction =
   | 'file:new'
   | 'file:open'
+  | 'file:reload'
   | 'file:save'
   | 'file:save-as'
   | 'file:export-html'

--- a/tests/unit/reload-document.test.ts
+++ b/tests/unit/reload-document.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest';
+import { reloadDocument } from '@renderer/features/workspace/lib/reload-document';
+import type { DocumentHandle } from '@shared/types';
+
+const onDisk: DocumentHandle = {
+  path: '/notes/draft.md',
+  name: 'draft.md',
+  content: 'updated on disk',
+};
+
+describe('reloadDocument', () => {
+  it('does nothing when no file is open', async () => {
+    const readDocument = vi.fn();
+
+    const outcome = await reloadDocument({
+      path: null,
+      isDirty: false,
+      readDocument,
+    });
+
+    expect(outcome).toEqual({ status: 'nothing-to-reload' });
+    expect(readDocument).not.toHaveBeenCalled();
+  });
+
+  it('reloads the file from disk', async () => {
+    const readDocument = vi.fn().mockResolvedValue(onDisk);
+
+    const outcome = await reloadDocument({
+      path: '/notes/draft.md',
+      isDirty: false,
+      readDocument,
+    });
+
+    expect(outcome).toEqual({ status: 'reloaded', document: onDisk });
+    expect(readDocument).toHaveBeenCalledWith('/notes/draft.md');
+  });
+
+  it('reports a file that no longer exists', async () => {
+    const readDocument = vi.fn().mockResolvedValue(null);
+
+    const outcome = await reloadDocument({
+      path: '/notes/deleted.md',
+      isDirty: false,
+      readDocument,
+    });
+
+    expect(outcome).toEqual({ status: 'file-not-found' });
+  });
+
+  it('refuses to reload over unsaved changes', async () => {
+    const readDocument = vi.fn();
+
+    const outcome = await reloadDocument({
+      path: '/notes/draft.md',
+      isDirty: true,
+      readDocument,
+    });
+
+    expect(outcome).toEqual({ status: 'blocked-unsaved' });
+  });
+
+  it('does not read from disk when there are unsaved changes', async () => {
+    const readDocument = vi.fn().mockResolvedValue(onDisk);
+
+    await reloadDocument({
+      path: '/notes/draft.md',
+      isDirty: true,
+      readDocument,
+    });
+
+    // The dirty check must short-circuit before the read, so a slow or failing
+    // read can never race ahead of it and replace the buffer.
+    expect(readDocument).not.toHaveBeenCalled();
+  });
+
+  it('prefers the no-file outcome over the dirty check', async () => {
+    const readDocument = vi.fn();
+
+    const outcome = await reloadDocument({
+      path: null,
+      isDirty: true,
+      readDocument,
+    });
+
+    expect(outcome).toEqual({ status: 'nothing-to-reload' });
+  });
+});


### PR DESCRIPTION
## Problem

Triggering Electron's native `role: 'reload'` (Developer → Reload / Ctrl+R) while a Markdown file is open discards all editor state. The editor resets to an empty untitled document and the previously open file must be reopened manually.

**Root cause:** `webContents.reload()` performs a full renderer-process restart equivalent to a browser page refresh. On restart, the Zustand workspace store re-initialises from a hardcoded `untitledDocument` value with no persistence of the open file path, so the loaded file is lost.

Two additional factors made this worse:
- The Developer submenu (where Reload lived) is guarded by an `isDev` check (`process.env.ELECTRON_RENDERER_URL`), so it was invisible in production builds entirely.
- The app sets `autoHideMenuBar: true` on a frameless window, so the native menu bar is not reliably accessible on Linux regardless.

## Solution

Replace the native renderer reload with a `file:reload` IPC action that re-reads the current file from disk and updates the editor in-place, with no renderer restart.

## Changes

- **`src/shared/types.ts`** — add `'file:reload'` to the `MenuAction` union
- **`src/main/menu.ts`** — add a Reload item to the File menu (outside the `isDev` guard) wired to the `file:reload` action; remove it from the Developer submenu
- **`src/renderer/src/features/workspace/hooks/use-document-actions.ts`** — handle `'file:reload'`: read the current file path from the workspace store, call `window.marky.openDocumentFromPath`, update the store in-place; show an info notice if no file is open
- **`src/renderer/src/features/titlebar/components/title-bar.tsx`** — add a Reload button (RefreshCw icon, Ctrl+R tooltip) to the custom titlebar so the action is visible and reachable in production builds where the native menu bar is not shown
- **`src/renderer/src/App.tsx`** — pass `onReload` prop to `TitleBar`
- **`src/renderer/src/i18n/`** — add `titlebar.reload`, `notice.reloaded`, and `notice.nothingToReload` keys for en, pt-BR, and es locales

## Test plan

- [ ] Open a `.md` file in Marky
- [ ] Modify the file externally (another editor, a script, etc.)
- [ ] Click the Reload button in the titlebar (or press Ctrl+R) — editor should update to show the new content
- [ ] With no file open (untitled document), click Reload — should show info notice "No saved file is open"
- [ ] Run `npm run build && npm run preview` — Reload button is visible in the titlebar in production

## Notes

Parts of this fix were developed with AI assistance. The code has been reviewed, tested manually, and understood before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)