### PR TITLE
Add color themes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@uiw/react-codemirror": "^4.25.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "codemirror-lang-mermaid": "^0.5.0",
         "electron-updater": "^6.6.2",
         "lucide-react": "^1.27.0",
         "mermaid": "^11.12.0",
@@ -5226,6 +5227,17 @@
         "@codemirror/search": "^6.0.0",
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0"
+      }
+    },
+    "node_modules/codemirror-lang-mermaid": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/codemirror-lang-mermaid/-/codemirror-lang-mermaid-0.5.0.tgz",
+      "integrity": "sha512-Taw/2gPCyNArQJCxIP/HSUif+3zrvD+6Ugt7KJZ2dUKou/8r3ZhcfG8krNTZfV2iu8AuGnymKuo7bLPFyqsh/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.9.0",
+        "@lezer/highlight": "^1.1.6",
+        "@lezer/lr": "^1.3.10"
       }
     },
     "node_modules/color-convert": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@codemirror/lang-markdown": "^6.3.4",
         "@codemirror/language": "^6.0.0",
+        "@codemirror/language-data": "^6.5.2",
         "@codemirror/state": "^6.5.2",
         "@codemirror/view": "^6.38.2",
         "@uiw/react-codemirror": "^4.25.2",
@@ -21,6 +22,7 @@
         "mermaid": "^11.12.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
+        "rehype-highlight": "^7.0.2",
         "rehype-stringify": "^10.0.1",
         "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
@@ -518,6 +520,30 @@
         "@lezer/common": "^1.1.0"
       }
     },
+    "node_modules/@codemirror/lang-angular": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-angular/-/lang-angular-0.1.4.tgz",
+      "integrity": "sha512-oap+gsltb/fzdlTQWD6BFF4bSLKcDnlxDsLdePiJpCVNKWXSTAbiiQeYI3UmES+BLAdkmIC1WjyztC1pi/bX4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.1.2",
+        "@codemirror/language": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.3"
+      }
+    },
+    "node_modules/@codemirror/lang-cpp": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-cpp/-/lang-cpp-6.0.3.tgz",
+      "integrity": "sha512-URM26M3vunFFn9/sm6rzqrBzDgfWuDixp85uTY49wKudToc2jTHUrKIGGKs+QWND+YLofNNZpxcNGRynFJfvgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/cpp": "^1.0.0"
+      }
+    },
     "node_modules/@codemirror/lang-css": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz",
@@ -529,6 +555,19 @@
         "@codemirror/state": "^6.0.0",
         "@lezer/common": "^1.0.2",
         "@lezer/css": "^1.1.7"
+      }
+    },
+    "node_modules/@codemirror/lang-go": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-go/-/lang-go-6.0.1.tgz",
+      "integrity": "sha512-7fNvbyNylvqCphW9HD6WFnRpcDjr+KXX/FgqXy5H5ZS0eC5edDljukm/yNgYkwTsgp2busdod50AOTIy6Jikfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/go": "^1.0.0"
       }
     },
     "node_modules/@codemirror/lang-html": {
@@ -548,6 +587,16 @@
         "@lezer/html": "^1.3.12"
       }
     },
+    "node_modules/@codemirror/lang-java": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-java/-/lang-java-6.0.2.tgz",
+      "integrity": "sha512-m5Nt1mQ/cznJY7tMfQTJchmrjdjQ71IDs+55d1GAa8DGaB8JXWsVCkVT284C3RTASaY43YknrK2X3hPO/J3MOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/java": "^1.0.0"
+      }
+    },
     "node_modules/@codemirror/lang-javascript": {
       "version": "6.2.5",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz",
@@ -561,6 +610,61 @@
         "@codemirror/view": "^6.17.0",
         "@lezer/common": "^1.0.0",
         "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-jinja": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-jinja/-/lang-jinja-6.0.1.tgz",
+      "integrity": "sha512-P5kyHLObzjtbGj16h+hyvZTxJhSjBEeSx4wMjbnAf3b0uwTy2+F0zGjMZL4PQOm/mh2eGZ5xUDVZXgwP783Nsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.2.0",
+        "@lezer/lr": "^1.4.0"
+      }
+    },
+    "node_modules/@codemirror/lang-json": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.2.tgz",
+      "integrity": "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/json": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-less": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-less/-/lang-less-6.0.2.tgz",
+      "integrity": "sha512-EYdQTG22V+KUUk8Qq582g7FMnCZeEHsyuOJisHRft/mQ+ZSZ2w51NupvDUHiqtsOy7It5cHLPGfHQLpMh9bqpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-css": "^6.2.0",
+        "@codemirror/language": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-liquid": {
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-liquid/-/lang-liquid-6.3.2.tgz",
+      "integrity": "sha512-6PDVU3ZnfeYyz1at1E/ttorErZvZFXXt1OPhtfe1EZJ2V2iDFa0CwPqPgG5F7NXN0yONGoBogKmFAafKTqlwIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.1"
       }
     },
     "node_modules/@codemirror/lang-markdown": {
@@ -578,6 +682,124 @@
         "@lezer/markdown": "^1.0.0"
       }
     },
+    "node_modules/@codemirror/lang-php": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-php/-/lang-php-6.0.2.tgz",
+      "integrity": "sha512-ZKy2v1n8Fc8oEXj0Th0PUMXzQJ0AIR6TaZU+PbDHExFwdu+guzOA4jmCHS1Nz4vbFezwD7LyBdDnddSJeScMCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/php": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-python": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-6.2.1.tgz",
+      "integrity": "sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.3.2",
+        "@codemirror/language": "^6.8.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.1",
+        "@lezer/python": "^1.1.4"
+      }
+    },
+    "node_modules/@codemirror/lang-rust": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-rust/-/lang-rust-6.0.2.tgz",
+      "integrity": "sha512-EZaGjCUegtiU7kSMvOfEZpaCReowEf3yNidYu7+vfuGTm9ow4mthAparY5hisJqOHmJowVH3Upu+eJlUji6qqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/rust": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-sass": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-sass/-/lang-sass-6.0.2.tgz",
+      "integrity": "sha512-l/bdzIABvnTo1nzdY6U+kPAC51czYQcOErfzQ9zSm9D8GmNPD0WTW8st/CJwBTPLO8jlrbyvlSEcN20dc4iL0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-css": "^6.2.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/sass": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-sql": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-sql/-/lang-sql-6.10.0.tgz",
+      "integrity": "sha512-6ayPkEd/yRw0XKBx5uAiToSgGECo/GY2NoJIHXIIQh1EVwLuKoU8BP/qK0qH5NLXAbtJRLuT73hx7P9X34iO4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-vue": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-vue/-/lang-vue-0.1.3.tgz",
+      "integrity": "sha512-QSKdtYTDRhEHCfo5zOShzxCmqKJvgGrZwDQSdbvCRJ5pRLWBS7pD/8e/tH44aVQT6FKm0t6RVNoSUWHOI5vNug==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.1.2",
+        "@codemirror/language": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.1"
+      }
+    },
+    "node_modules/@codemirror/lang-wast": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-wast/-/lang-wast-6.0.2.tgz",
+      "integrity": "sha512-Imi2KTpVGm7TKuUkqyJ5NRmeFWF7aMpNiwHnLQe0x9kmrxElndyH0K6H/gXtWwY6UshMRAhpENsgfpSwsgmC6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-xml": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-xml/-/lang-xml-6.1.0.tgz",
+      "integrity": "sha512-3z0blhicHLfwi2UgkZYRPioSgVTo9PV5GP5ducFH6FaHy0IAJRg+ixj5gTR1gnT/glAIC8xv4w2VL1LoZfs+Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/xml": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-yaml": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-yaml/-/lang-yaml-6.1.3.tgz",
+      "integrity": "sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.2.0",
+        "@lezer/lr": "^1.0.0",
+        "@lezer/yaml": "^1.0.0"
+      }
+    },
     "node_modules/@codemirror/language": {
       "version": "6.12.4",
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
@@ -590,6 +812,46 @@
         "@lezer/highlight": "^1.0.0",
         "@lezer/lr": "^1.0.0",
         "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/language-data": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/language-data/-/language-data-6.5.2.tgz",
+      "integrity": "sha512-CPkWBKrNS8stYbEU5kwBwTf3JB1kghlbh4FSAwzGW2TEscdeHHH4FGysREW86Mqnj3Qn09s0/6Ea/TutmoTobg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-angular": "^0.1.0",
+        "@codemirror/lang-cpp": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-go": "^6.0.0",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/lang-java": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/lang-jinja": "^6.0.0",
+        "@codemirror/lang-json": "^6.0.0",
+        "@codemirror/lang-less": "^6.0.0",
+        "@codemirror/lang-liquid": "^6.0.0",
+        "@codemirror/lang-markdown": "^6.0.0",
+        "@codemirror/lang-php": "^6.0.0",
+        "@codemirror/lang-python": "^6.0.0",
+        "@codemirror/lang-rust": "^6.0.0",
+        "@codemirror/lang-sass": "^6.0.0",
+        "@codemirror/lang-sql": "^6.0.0",
+        "@codemirror/lang-vue": "^0.1.1",
+        "@codemirror/lang-wast": "^6.0.0",
+        "@codemirror/lang-xml": "^6.0.0",
+        "@codemirror/lang-yaml": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/legacy-modes": "^6.4.0"
+      }
+    },
+    "node_modules/@codemirror/legacy-modes": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-6.5.3.tgz",
+      "integrity": "sha512-xCsmIzH78MyWkib9jlPaaun57XNkfbMIhagfaZVd0iLTqlpw3jXaIcbZm72MTmmn64eTZpBVNjbyYh+QXnxRsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0"
       }
     },
     "node_modules/@codemirror/lint": {
@@ -2372,10 +2634,32 @@
       "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
       "license": "MIT"
     },
+    "node_modules/@lezer/cpp": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@lezer/cpp/-/cpp-1.1.6.tgz",
+      "integrity": "sha512-vh9gWWJOXFVY8HBHK3Twzq8MgwG2iN4GSyzBP9sCGTe37P15x2R14VaBQk0VA0ezTRN1KHYBBsHhvpGZ2Xy/pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
     "node_modules/@lezer/css": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.4.tgz",
       "integrity": "sha512-N+tn9tej2hPvyKgHEApMOQfHczDJCwxrRFS3SPn9QjYN+uwHvEDnCgKRrb3mxDYxRS8sKMM8fhC3+lc04Abz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/go": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@lezer/go/-/go-1.0.1.tgz",
+      "integrity": "sha512-xToRsYxwsgJNHTgNdStpcvmbVuKxTapV0dM0wey1geMMRc9aggoVyKgzYp41D2/vVOx+Ii4hmE206kvxIXBVXQ==",
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.2.0",
@@ -2403,6 +2687,17 @@
         "@lezer/lr": "^1.0.0"
       }
     },
+    "node_modules/@lezer/java": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@lezer/java/-/java-1.1.3.tgz",
+      "integrity": "sha512-yHquUfujwg6Yu4Fd1GNHCvidIvJwi/1Xu2DaKl/pfWIA2c1oXkVvawH3NyXhCaFx4OdlYBVX5wvz2f7Aoa/4Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
     "node_modules/@lezer/javascript": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
@@ -2412,6 +2707,17 @@
         "@lezer/common": "^1.2.0",
         "@lezer/highlight": "^1.1.3",
         "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/json": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.3.tgz",
+      "integrity": "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
       }
     },
     "node_modules/@lezer/lr": {
@@ -2431,6 +2737,72 @@
       "dependencies": {
         "@lezer/common": "^1.5.0",
         "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/php": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@lezer/php/-/php-1.0.5.tgz",
+      "integrity": "sha512-W7asp9DhM6q0W6DYNwIkLSKOvxlXRrif+UXBMxzsJUuqmhE7oVU+gS3THO4S/Puh7Xzgm858UNaFi6dxTP8dJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.1.0"
+      }
+    },
+    "node_modules/@lezer/python": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@lezer/python/-/python-1.1.19.tgz",
+      "integrity": "sha512-MhQIURHRytsNzP/YXnqpYKW6la6voAH3kyplTOOiCdjyFY6cWWGFVmYVdHIPrElqSDf4iCDktQCockB9FxuhzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/rust": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@lezer/rust/-/rust-1.0.2.tgz",
+      "integrity": "sha512-Lz5sIPBdF2FUXcWeCu1//ojFAZqzTQNRga0aYv6dYXqJqPfMdCAI0NzajWUd4Xijj1IKJLtjoXRPMvTKWBcqKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/sass": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lezer/sass/-/sass-1.1.0.tgz",
+      "integrity": "sha512-3mMGdCTUZ/84ArHOuXWQr37pnf7f+Nw9ycPUeKX+wu19b7pSMcZGLbaXwvD2APMBDOGxPmpK/O6S1v1EvLoqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/xml": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@lezer/xml/-/xml-1.0.6.tgz",
+      "integrity": "sha512-CdDwirL0OEaStFue/66ZmFSeppuL6Dwjlk8qk153mSQwiSH/Dlri4GNymrNWnUmPl2Um7QfV1FO9KFUyX3Twww==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/yaml": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@lezer/yaml/-/yaml-1.0.4.tgz",
+      "integrity": "sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.4.0"
       }
     },
     "node_modules/@malept/cross-spawn-promise": {
@@ -2721,9 +3093,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2738,9 +3107,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2755,9 +3121,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2772,9 +3135,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2789,9 +3149,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2806,9 +3163,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2823,9 +3177,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2840,9 +3191,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2857,9 +3205,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2874,9 +3219,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2891,9 +3233,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2908,9 +3247,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2925,9 +3261,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7327,6 +7660,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-html": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
@@ -7344,6 +7690,22 @@
         "space-separated-tokens": "^2.0.0",
         "stringify-entities": "^4.0.0",
         "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -7378,6 +7740,15 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/hosted-git-info": {
@@ -8071,6 +8442,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/lowlight": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
+      "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.0.0",
+        "highlight.js": "~11.11.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/lru-cache": {
@@ -10119,6 +10505,23 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/rehype-highlight": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-highlight/-/rehype-highlight-7.0.2.tgz",
+      "integrity": "sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "lowlight": "^3.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rehype-stringify": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
@@ -11827,6 +12230,20 @@
         "is-plain-obj": "^4.0.0",
         "trough": "^2.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@uiw/react-codemirror": "^4.25.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "codemirror-lang-mermaid": "^0.5.0",
     "electron-updater": "^6.6.2",
     "lucide-react": "^1.27.0",
     "mermaid": "^11.12.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@codemirror/lang-markdown": "^6.3.4",
     "@codemirror/language": "^6.0.0",
+    "@codemirror/language-data": "^6.5.2",
     "@codemirror/state": "^6.5.2",
     "@codemirror/view": "^6.38.2",
     "@uiw/react-codemirror": "^4.25.2",
@@ -38,6 +39,7 @@
     "mermaid": "^11.12.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "rehype-highlight": "^7.0.2",
     "rehype-stringify": "^10.0.1",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",

--- a/src/renderer/src/features/editor/components/editor-pane.tsx
+++ b/src/renderer/src/features/editor/components/editor-pane.tsx
@@ -10,9 +10,13 @@ import CodeMirror from '@uiw/react-codemirror';
 import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
 import { languages } from '@codemirror/language-data';
 import { syntaxHighlighting } from '@codemirror/language';
+import { mermaidLanguageDescription } from 'codemirror-lang-mermaid';
 import { EditorView } from '@codemirror/view';
 import { TableProperties } from 'lucide-react';
 import { markyHighlightStyle } from '../lib/highlight-style';
+import { mermaidHighlightStyle } from '../lib/mermaid-highlight';
+
+const codeLanguages = [mermaidLanguageDescription, ...languages];
 import { Button } from '@renderer/components/ui/button';
 import { useTranslation } from '@renderer/i18n';
 import { useEditorStore } from '../store';
@@ -85,8 +89,9 @@ export function EditorPane({ value, onChange, onReady }: EditorPaneProps) {
 
   const extensions = useMemo(
     () => [
-      markdown({ base: markdownLanguage, codeLanguages: languages }),
+      markdown({ base: markdownLanguage, codeLanguages }),
       syntaxHighlighting(markyHighlightStyle),
+      syntaxHighlighting(mermaidHighlightStyle),
       tableNavigationExtension,
       formattingKeymap,
       EditorView.lineWrapping,

--- a/src/renderer/src/features/editor/components/editor-pane.tsx
+++ b/src/renderer/src/features/editor/components/editor-pane.tsx
@@ -8,8 +8,11 @@ import {
 } from 'react';
 import CodeMirror from '@uiw/react-codemirror';
 import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
+import { languages } from '@codemirror/language-data';
+import { syntaxHighlighting } from '@codemirror/language';
 import { EditorView } from '@codemirror/view';
 import { TableProperties } from 'lucide-react';
+import { markyHighlightStyle } from '../lib/highlight-style';
 import { Button } from '@renderer/components/ui/button';
 import { useTranslation } from '@renderer/i18n';
 import { useEditorStore } from '../store';
@@ -82,7 +85,8 @@ export function EditorPane({ value, onChange, onReady }: EditorPaneProps) {
 
   const extensions = useMemo(
     () => [
-      markdown({ base: markdownLanguage }),
+      markdown({ base: markdownLanguage, codeLanguages: languages }),
+      syntaxHighlighting(markyHighlightStyle),
       tableNavigationExtension,
       formattingKeymap,
       EditorView.lineWrapping,

--- a/src/renderer/src/features/editor/lib/highlight-style.ts
+++ b/src/renderer/src/features/editor/lib/highlight-style.ts
@@ -1,0 +1,56 @@
+import { HighlightStyle } from '@codemirror/language';
+import { tags as t } from '@lezer/highlight';
+
+const color = {
+  foreground: 'hsl(var(--syntax-foreground))',
+  comment: 'hsl(var(--syntax-comment))',
+  string: 'hsl(var(--syntax-string))',
+  keyword: 'hsl(var(--syntax-keyword))',
+  function: 'hsl(var(--syntax-function))',
+  class: 'hsl(var(--syntax-class))',
+  constant: 'hsl(var(--syntax-constant))',
+  parameter: 'hsl(var(--syntax-parameter))',
+  error: 'hsl(var(--syntax-error))',
+  tag: 'hsl(var(--syntax-tag))',
+  accent: 'hsl(var(--primary))',
+} as const;
+
+/**
+ * One highlight style shared by every theme. Colours resolve through the
+ * `--syntax-*` CSS variables, so switching palette re-tints the editor with no
+ * extension reconfiguration. Covers Markdown tokens and the languages CodeMirror
+ * lazily loads for fenced code blocks.
+ */
+export const markyHighlightStyle = HighlightStyle.define([
+  // --- Markdown structural tokens ---
+  { tag: t.heading, color: color.accent, fontWeight: '700' },
+  { tag: t.strong, color: color.foreground, fontWeight: '700' },
+  { tag: t.emphasis, color: color.foreground, fontStyle: 'italic' },
+  { tag: t.strikethrough, textDecoration: 'line-through' },
+  { tag: [t.link, t.url], color: color.accent, textDecoration: 'underline' },
+  { tag: t.quote, color: color.comment, fontStyle: 'italic' },
+  { tag: t.monospace, color: color.string },
+  { tag: t.list, color: color.keyword },
+  { tag: [t.processingInstruction, t.meta], color: color.comment },
+
+  // --- Programming-language tokens (embedded fenced code) ---
+  { tag: t.comment, color: color.comment, fontStyle: 'italic' },
+  { tag: [t.keyword, t.modifier, t.operatorKeyword], color: color.keyword },
+  { tag: [t.string, t.special(t.string), t.regexp], color: color.string },
+  {
+    tag: [t.function(t.variableName), t.function(t.propertyName)],
+    color: color.function,
+  },
+  { tag: [t.typeName, t.className, t.namespace], color: color.class },
+  {
+    tag: [t.number, t.bool, t.null, t.atom, t.constant(t.variableName)],
+    color: color.constant,
+  },
+  {
+    tag: [t.propertyName, t.attributeName, t.variableName],
+    color: color.parameter,
+  },
+  { tag: [t.tagName, t.angleBracket], color: color.tag },
+  { tag: [t.operator, t.punctuation, t.separator], color: color.foreground },
+  { tag: t.invalid, color: color.error },
+]);

--- a/src/renderer/src/features/editor/lib/mermaid-highlight.ts
+++ b/src/renderer/src/features/editor/lib/mermaid-highlight.ts
@@ -1,0 +1,65 @@
+import { HighlightStyle } from '@codemirror/language';
+import type { Tag } from '@lezer/highlight';
+import {
+  flowchartTags,
+  ganttTags,
+  journeyTags,
+  mermaidTags,
+  mindmapTags,
+  pieTags,
+  requirementTags,
+  sequenceTags,
+} from 'codemirror-lang-mermaid';
+
+const color = {
+  foreground: 'hsl(var(--syntax-foreground))',
+  comment: 'hsl(var(--syntax-comment))',
+  string: 'hsl(var(--syntax-string))',
+  keyword: 'hsl(var(--syntax-keyword))',
+  function: 'hsl(var(--syntax-function))',
+  constant: 'hsl(var(--syntax-constant))',
+  parameter: 'hsl(var(--syntax-parameter))',
+} as const;
+
+/**
+ * `codemirror-lang-mermaid` styles its grammar with its own `Tag` objects
+ * rather than the standard `@lezer/highlight` tags, so the shared editor
+ * highlight style cannot colour them. Map each tag to the theme palette by the
+ * role its name implies.
+ */
+function colorFor(name: string): string {
+  const n = name.toLowerCase();
+  if (n.includes('comment')) return color.comment;
+  if (n.includes('text') || n.includes('string') || n.includes('title'))
+    return color.string;
+  if (n.includes('number') || n.includes('score')) return color.constant;
+  if (n.includes('arrow') || n.includes('link') || n.includes('edge'))
+    return color.function;
+  if (
+    n.includes('keyword') ||
+    n === 'diagramname' ||
+    n === 'orientation' ||
+    n === 'showdata'
+  )
+    return color.keyword;
+  if (n === 'nodeid' || n === 'actor' || n === 'position')
+    return color.parameter;
+  return color.foreground;
+}
+
+const tagGroups: Array<Record<string, Tag>> = [
+  mermaidTags,
+  mindmapTags,
+  pieTags,
+  flowchartTags,
+  sequenceTags,
+  journeyTags,
+  requirementTags,
+  ganttTags,
+];
+
+const specs = tagGroups.flatMap((group) =>
+  Object.entries(group).map(([name, tag]) => ({ tag, color: colorFor(name) })),
+);
+
+export const mermaidHighlightStyle = HighlightStyle.define(specs);

--- a/src/renderer/src/features/export/lib/export-document.ts
+++ b/src/renderer/src/features/export/lib/export-document.ts
@@ -64,6 +64,19 @@ function exportStyles(font: ExportFont) {
     padding: 0.2em 0.4em;
   }
   pre code { background: transparent; border: none; padding: 0; font-size: inherit; }
+  /* Static, theme-independent code highlighting (GitHub-light palette). */
+  .hljs-comment, .hljs-quote { color: #6e7781; font-style: italic; }
+  .hljs-keyword, .hljs-selector-tag, .hljs-literal, .hljs-doctag { color: #cf222e; }
+  .hljs-string, .hljs-meta .hljs-string, .hljs-regexp { color: #0a3069; }
+  .hljs-title, .hljs-title.function_, .hljs-section { color: #8250df; }
+  .hljs-type, .hljs-title.class_, .hljs-built_in, .hljs-class .hljs-title { color: #953800; }
+  .hljs-number, .hljs-symbol, .hljs-bullet { color: #0550ae; }
+  .hljs-params, .hljs-attr, .hljs-attribute, .hljs-variable, .hljs-template-variable, .hljs-meta { color: #953800; }
+  .hljs-name, .hljs-tag { color: #116329; }
+  .hljs-deletion { color: #82071e; background: #ffebe9; }
+  .hljs-addition { color: #116329; background: #dafbe1; }
+  .hljs-emphasis { font-style: italic; }
+  .hljs-strong { font-weight: 700; }
   table {
     width: 100%;
     border-collapse: collapse;

--- a/src/renderer/src/features/preview/components/preview-pane.tsx
+++ b/src/renderer/src/features/preview/components/preview-pane.tsx
@@ -62,10 +62,11 @@ let initializedConfigKey: string | null = null;
 
 function ensureMermaid(
   theme: MermaidTheme,
+  colorTheme: string,
   previewFontFamily: string,
   previewFontSize: number,
 ) {
-  const configKey = `${theme}:${previewFontFamily}:${previewFontSize}`;
+  const configKey = `${theme}:${colorTheme}:${previewFontFamily}:${previewFontSize}`;
 
   if (initializedConfigKey !== configKey) {
     mermaid.initialize(getMermaidConfig(previewFontFamily, previewFontSize));
@@ -100,6 +101,7 @@ export function PreviewPane({ markdown, documentPath }: PreviewPaneProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const { t } = useTranslation();
   const theme = useSettingsStore((state) => state.settings.theme);
+  const colorTheme = useSettingsStore((state) => state.settings.colorTheme);
   const previewFontFamily = useSettingsStore(
     (state) => state.settings.previewFontFamily,
   );
@@ -112,7 +114,7 @@ export function PreviewPane({ markdown, documentPath }: PreviewPaneProps) {
   );
 
   useEffect(() => {
-    ensureMermaid(theme, previewFontFamily, previewFontSize);
+    ensureMermaid(theme, colorTheme, previewFontFamily, previewFontSize);
 
     const container = containerRef.current;
     if (!container) return;
@@ -160,7 +162,7 @@ export function PreviewPane({ markdown, documentPath }: PreviewPaneProps) {
         if (!parent) return;
 
         const source = block.textContent ?? '';
-        const cacheKey = `${theme}:${previewFontFamily}:${previewFontSize}:${source}`;
+        const cacheKey = `${theme}:${colorTheme}:${previewFontFamily}:${previewFontSize}:${source}`;
 
         try {
           let svg = mermaidCache.get(cacheKey);
@@ -194,7 +196,7 @@ export function PreviewPane({ markdown, documentPath }: PreviewPaneProps) {
     return () => {
       cancelled = true;
     };
-  }, [html, previewFontFamily, previewFontSize, theme, t]);
+  }, [html, previewFontFamily, previewFontSize, theme, colorTheme, t]);
 
   return <div ref={containerRef} className="preview-prose dark:prose-invert" />;
 }

--- a/src/renderer/src/features/preview/lib/markdown.ts
+++ b/src/renderer/src/features/preview/lib/markdown.ts
@@ -3,6 +3,7 @@ import remarkParse from 'remark-parse';
 import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
 import remarkRehype from 'remark-rehype';
+import rehypeHighlight from 'rehype-highlight';
 import rehypeStringify from 'rehype-stringify';
 import type { Root } from 'hast';
 import { visit } from 'unist-util-visit';
@@ -70,7 +71,10 @@ function createProcessor(baseDir?: string) {
     .use(remarkGfm)
     .use(remarkBreaks)
     .use(remarkRehype)
-    .use(rehypeDropUnsafeLinks());
+    .use(rehypeDropUnsafeLinks())
+    // Mermaid blocks are rendered by the preview/export, so leave them as plain
+    // text; unknown languages are ignored rather than throwing.
+    .use(rehypeHighlight, { plainText: ['mermaid'], ignoreMissing: true });
 
   if (baseDir) {
     pipeline.use(rehypeResolveLocalImages(baseDir));

--- a/src/renderer/src/features/settings/components/settings-dialog.tsx
+++ b/src/renderer/src/features/settings/components/settings-dialog.tsx
@@ -11,6 +11,7 @@ import {
   type FontOption,
   type LoadedFontOptions,
 } from '../lib/font-options';
+import { THEMES } from '../lib/themes';
 import { useSettingsStore } from '../store';
 import { useTranslation, type TranslationKeys } from '@renderer/i18n';
 
@@ -284,6 +285,32 @@ export function SettingsDialog() {
                   <Moon className="size-4" />
                 )}
                 {theme === 'light' ? t('settings.light') : t('settings.dark')}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <p className={labelClass}>{t('settings.colorTheme')}</p>
+          <div className="grid grid-cols-3 gap-2">
+            {THEMES.map((option) => (
+              <button
+                key={option.name}
+                type="button"
+                onClick={() => updateSettings({ colorTheme: option.name })}
+                aria-pressed={settings.colorTheme === option.name}
+                className={cn(
+                  'flex items-center gap-2 rounded-xl border px-3 py-2 text-sm font-medium transition-colors',
+                  settings.colorTheme === option.name
+                    ? 'border-primary bg-primary/10 text-foreground'
+                    : 'border-border bg-background text-muted-foreground hover:bg-accent',
+                )}
+              >
+                <span
+                  className="size-4 shrink-0 rounded-full ring-1 ring-inset ring-black/10"
+                  style={{ backgroundColor: option.swatch }}
+                />
+                {option.label}
               </button>
             ))}
           </div>

--- a/src/renderer/src/features/settings/hooks/use-appearance.ts
+++ b/src/renderer/src/features/settings/hooks/use-appearance.ts
@@ -1,13 +1,22 @@
-import { useEffect } from 'react';
+import { useLayoutEffect } from 'react';
 import {
   toEditorFontFamilyCss,
   toPreviewFontFamilyCss,
 } from '../lib/font-options';
 import { useSettingsStore } from '../store';
 
-/** Reflects the appearance settings onto the document element. */
+/**
+ * Reflects the appearance settings onto the document element.
+ *
+ * Uses layout effects so the theme class and CSS variables land on `<html>`
+ * before any component's passive effect reads computed styles. Passive effects
+ * run child-before-parent, so a plain effect here (this hook lives at the app
+ * root) would apply the theme *after* the preview re-renders — leaving Mermaid
+ * diagrams drawn with the previous palette's variables.
+ */
 export function useAppearance() {
   const theme = useSettingsStore((state) => state.settings.theme);
+  const colorTheme = useSettingsStore((state) => state.settings.colorTheme);
   const editorFontFamily = useSettingsStore(
     (state) => state.settings.editorFontFamily,
   );
@@ -21,12 +30,17 @@ export function useAppearance() {
     (state) => state.settings.previewFontSize,
   );
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const root = globalThis.document.documentElement;
     root.classList.toggle('dark', theme === 'dark');
   }, [theme]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
+    const root = globalThis.document.documentElement;
+    root.setAttribute('data-color-theme', colorTheme);
+  }, [colorTheme]);
+
+  useLayoutEffect(() => {
     const root = globalThis.document.documentElement;
     root.style.setProperty(
       '--editor-font-family',

--- a/src/renderer/src/features/settings/lib/themes.ts
+++ b/src/renderer/src/features/settings/lib/themes.ts
@@ -1,0 +1,25 @@
+import type { ThemeName } from '@shared/types';
+
+export type ThemeMeta = {
+  name: ThemeName;
+  /** Proper-noun display name; not translated. */
+  label: string;
+  /** Accent color used for the picker swatch. */
+  swatch: string;
+};
+
+/** Colour themes offered by the app, in display order. */
+export const THEMES: ThemeMeta[] = [
+  { name: 'amethyst', label: 'Amethyst', swatch: '#9580ff' },
+  { name: 'rose', label: 'Rose', swatch: '#ff80bf' },
+  { name: 'jade', label: 'Jade', swatch: '#80ffea' },
+  { name: 'amber', label: 'Amber', swatch: '#ffff80' },
+  { name: 'coral', label: 'Coral', swatch: '#ff9580' },
+  { name: 'sapphire', label: 'Sapphire', swatch: '#80bfff' },
+];
+
+export const THEME_NAMES: ThemeName[] = THEMES.map((theme) => theme.name);
+
+export function isThemeName(value: string): value is ThemeName {
+  return THEME_NAMES.includes(value as ThemeName);
+}

--- a/src/renderer/src/i18n/en.ts
+++ b/src/renderer/src/i18n/en.ts
@@ -10,6 +10,7 @@ export const en: TranslationKeys = {
   'settings.theme': 'Theme',
   'settings.light': 'Light',
   'settings.dark': 'Dark',
+  'settings.colorTheme': 'Color theme',
   'settings.writing': 'Writing',
   'settings.editorFont': 'Editor font',
   'settings.previewFont': 'Preview font',

--- a/src/renderer/src/i18n/es.ts
+++ b/src/renderer/src/i18n/es.ts
@@ -10,6 +10,7 @@ export const es: TranslationKeys = {
   'settings.theme': 'Tema',
   'settings.light': 'Claro',
   'settings.dark': 'Oscuro',
+  'settings.colorTheme': 'Tema de color',
   'settings.writing': 'Escritura',
   'settings.editorFont': 'Fuente del editor',
   'settings.previewFont': 'Fuente de la vista previa',

--- a/src/renderer/src/i18n/pt-BR.ts
+++ b/src/renderer/src/i18n/pt-BR.ts
@@ -10,6 +10,7 @@ export const ptBR: TranslationKeys = {
   'settings.theme': 'Tema',
   'settings.light': 'Claro',
   'settings.dark': 'Escuro',
+  'settings.colorTheme': 'Tema de cor',
   'settings.writing': 'Escrita',
   'settings.editorFont': 'Fonte do editor',
   'settings.previewFont': 'Fonte da pré-visualização',

--- a/src/renderer/src/i18n/types.ts
+++ b/src/renderer/src/i18n/types.ts
@@ -8,6 +8,7 @@ export type TranslationKeys = {
   'settings.theme': string;
   'settings.light': string;
   'settings.dark': string;
+  'settings.colorTheme': string;
   'settings.writing': string;
   'settings.editorFont': string;
   'settings.previewFont': string;

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -5,8 +5,60 @@
 @tailwind utilities;
 
 @layer base {
+
   :root {
     color-scheme: light;
+    --radius: 1.35rem;
+    --editor-font-family: 'IBM Plex Mono', monospace;
+    --editor-font-size: 16px;
+    --preview-font-family: 'IBM Plex Sans', sans-serif;
+    --preview-font-size: 16px;
+    --app-shell-overlay:
+      radial-gradient(
+        circle at top,
+        hsl(var(--primary) / 0.16),
+        transparent 40%
+      ),
+      linear-gradient(
+        180deg,
+        hsl(var(--secondary) / 0.55),
+        hsl(var(--background))
+      );
+    --app-grain-opacity: 0.5;
+    --texture-grain: radial-gradient(
+      circle at 1px 1px,
+      hsl(var(--primary) / 0.09) 1px,
+      transparent 0
+    );
+    --shadow-panel: 0 18px 44px hsl(var(--primary) / 0.16);
+  }
+
+  .dark {
+    color-scheme: dark;
+    --app-shell-overlay:
+      radial-gradient(
+        circle at top,
+        hsl(var(--primary) / 0.3),
+        transparent 44%
+      ),
+      linear-gradient(
+        180deg,
+        hsl(var(--background) / 0.2),
+        hsl(var(--background))
+      );
+    --app-grain-opacity: 0.2;
+    --texture-grain: radial-gradient(
+      circle at 1px 1px,
+      hsl(var(--primary) / 0.08) 1px,
+      transparent 0
+    );
+    --shadow-panel: 0 18px 44px hsl(var(--primary) / 0.2);
+  }
+
+/* ==== LIGHT THEMES ==== */
+
+  :root,
+  :root[data-color-theme='amethyst'] {
     --background: 264 58% 97%;
     --foreground: 268 24% 18%;
     --card: 270 100% 99%;
@@ -37,28 +89,16 @@
     --editor-cursor: hsl(var(--primary));
     --editor-active-line: hsl(var(--primary) / 0.07);
     --editor-selection: hsl(var(--primary) / 0.22);
-    --editor-font-family: 'IBM Plex Mono', monospace;
-    --editor-font-size: 16px;
-    --preview-font-family: 'IBM Plex Sans', sans-serif;
-    --preview-font-size: 16px;
-    --app-shell-overlay:
-      radial-gradient(
-        circle at top,
-        rgba(169, 133, 246, 0.18),
-        transparent 38%
-      ),
-      linear-gradient(
-        180deg,
-        rgba(238, 230, 255, 0.95),
-        rgba(247, 243, 255, 0.99)
-      );
-    --app-grain-opacity: 0.5;
-    --texture-grain: radial-gradient(
-      circle at 1px 1px,
-      rgba(112, 83, 173, 0.09) 1px,
-      transparent 0
-    );
-    --shadow-panel: 0 18px 44px hsl(var(--primary) / 0.16);
+    --syntax-foreground: 268 24% 18%;
+    --syntax-comment: 250 18% 46%;
+    --syntax-string: 45 85% 32%;
+    --syntax-keyword: 330 72% 42%;
+    --syntax-function: 142 58% 30%;
+    --syntax-class: 182 62% 30%;
+    --syntax-constant: 258 60% 50%;
+    --syntax-parameter: 28 82% 40%;
+    --syntax-error: 0 70% 46%;
+    --syntax-tag: 330 72% 42%;
     --mermaid-primary-color: #dbcafc;
     --mermaid-primary-text-color: #382457;
     --mermaid-primary-border-color: #8663d1;
@@ -66,55 +106,302 @@
     --mermaid-secondary-color: #eee5ff;
     --mermaid-tertiary-color: #f8f4ff;
     --mermaid-edge-label-background: #f8f4ff;
-    --radius: 1.35rem;
   }
 
-  .dark {
-    color-scheme: dark;
-    --background: 270 36% 9%;
-    --foreground: 272 38% 89%;
-    --card: 270 30% 12%;
-    --card-foreground: 272 38% 89%;
-    --primary: 269 82% 74%;
-    --primary-foreground: 270 40% 11%;
-    --secondary: 271 23% 18%;
-    --secondary-foreground: 271 31% 82%;
-    --muted: 270 20% 15%;
-    --muted-foreground: 270 15% 63%;
-    --accent: 276 26% 22%;
-    --accent-foreground: 273 36% 86%;
+  :root[data-color-theme='rose'] {
+    --background: 344 58% 97%;
+    --foreground: 268 24% 18%;
+    --card: 350 100% 99%;
+    --card-foreground: 268 24% 18%;
+    --primary: 349 52% 49%;
+    --primary-foreground: 350 100% 99%;
+    --secondary: 345 50% 92%;
+    --secondary-foreground: 348 28% 28%;
+    --muted: 344 42% 94%;
+    --muted-foreground: 346 14% 44%;
+    --accent: 356 58% 90%;
+    --accent-foreground: 350 31% 27%;
+    --destructive: 353 70% 54%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 347 31% 84%;
+    --input: 347 31% 84%;
+    --ring: 349 52% 49%;
+    --editor-surface: 347 80% 98%;
+    --editor-surface-elevated: 350 100% 99%;
+    --preview-surface: 344 56% 96%;
+    --scrollbar-track: 344 42% 92%;
+    --scrollbar-thumb: 348 31% 74%;
+    --scrollbar-thumb-hover: 349 40% 63%;
+    --scrollbar-corner: 344 42% 92%;
+    --success-soft: 149 48% 92%;
+    --success-foreground: 150 49% 30%;
+    --editor-text: hsl(var(--foreground));
+    --editor-cursor: hsl(var(--primary));
+    --editor-active-line: hsl(var(--primary) / 0.07);
+    --editor-selection: hsl(var(--primary) / 0.22);
+    --syntax-foreground: 268 24% 18%;
+    --syntax-comment: 330 18% 46%;
+    --syntax-string: 45 85% 32%;
+    --syntax-keyword: 330 72% 42%;
+    --syntax-function: 142 58% 30%;
+    --syntax-class: 182 62% 30%;
+    --syntax-constant: 258 60% 50%;
+    --syntax-parameter: 28 82% 40%;
+    --syntax-error: 0 70% 46%;
+    --syntax-tag: 330 72% 42%;
+    --mermaid-primary-color: #fccada;
+    --mermaid-primary-text-color: #572432;
+    --mermaid-primary-border-color: #d16389;
+    --mermaid-line-color: #d16389;
+    --mermaid-secondary-color: #ffe5ed;
+    --mermaid-tertiary-color: #fff4f7;
+    --mermaid-edge-label-background: #fff4f7;
+  }
+
+  :root[data-color-theme='jade'] {
+    --background: 184 58% 97%;
+    --foreground: 268 24% 18%;
+    --card: 190 100% 99%;
+    --card-foreground: 268 24% 18%;
+    --primary: 189 52% 49%;
+    --primary-foreground: 190 100% 99%;
+    --secondary: 185 50% 92%;
+    --secondary-foreground: 188 28% 28%;
+    --muted: 184 42% 94%;
+    --muted-foreground: 186 14% 44%;
+    --accent: 196 58% 90%;
+    --accent-foreground: 190 31% 27%;
+    --destructive: 353 70% 54%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 187 31% 84%;
+    --input: 187 31% 84%;
+    --ring: 189 52% 49%;
+    --editor-surface: 187 80% 98%;
+    --editor-surface-elevated: 190 100% 99%;
+    --preview-surface: 184 56% 96%;
+    --scrollbar-track: 184 42% 92%;
+    --scrollbar-thumb: 188 31% 74%;
+    --scrollbar-thumb-hover: 189 40% 63%;
+    --scrollbar-corner: 184 42% 92%;
+    --success-soft: 149 48% 92%;
+    --success-foreground: 150 49% 30%;
+    --editor-text: hsl(var(--foreground));
+    --editor-cursor: hsl(var(--primary));
+    --editor-active-line: hsl(var(--primary) / 0.07);
+    --editor-selection: hsl(var(--primary) / 0.22);
+    --syntax-foreground: 268 24% 18%;
+    --syntax-comment: 170 18% 46%;
+    --syntax-string: 45 85% 32%;
+    --syntax-keyword: 330 72% 42%;
+    --syntax-function: 142 58% 30%;
+    --syntax-class: 182 62% 30%;
+    --syntax-constant: 258 60% 50%;
+    --syntax-parameter: 28 82% 40%;
+    --syntax-error: 0 70% 46%;
+    --syntax-tag: 330 72% 42%;
+    --mermaid-primary-color: #cafcfc;
+    --mermaid-primary-text-color: #245457;
+    --mermaid-primary-border-color: #63d1d0;
+    --mermaid-line-color: #63d1d0;
+    --mermaid-secondary-color: #e5ffff;
+    --mermaid-tertiary-color: #f4ffff;
+    --mermaid-edge-label-background: #f4ffff;
+  }
+
+  :root[data-color-theme='amber'] {
+    --background: 74 58% 97%;
+    --foreground: 268 24% 18%;
+    --card: 80 100% 99%;
+    --card-foreground: 268 24% 18%;
+    --primary: 79 52% 49%;
+    --primary-foreground: 80 100% 99%;
+    --secondary: 75 50% 92%;
+    --secondary-foreground: 78 28% 28%;
+    --muted: 74 42% 94%;
+    --muted-foreground: 76 14% 44%;
+    --accent: 86 58% 90%;
+    --accent-foreground: 80 31% 27%;
+    --destructive: 353 70% 54%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 77 31% 84%;
+    --input: 77 31% 84%;
+    --ring: 79 52% 49%;
+    --editor-surface: 77 80% 98%;
+    --editor-surface-elevated: 80 100% 99%;
+    --preview-surface: 74 56% 96%;
+    --scrollbar-track: 74 42% 92%;
+    --scrollbar-thumb: 78 31% 74%;
+    --scrollbar-thumb-hover: 79 40% 63%;
+    --scrollbar-corner: 74 42% 92%;
+    --success-soft: 149 48% 92%;
+    --success-foreground: 150 49% 30%;
+    --editor-text: hsl(var(--foreground));
+    --editor-cursor: hsl(var(--primary));
+    --editor-active-line: hsl(var(--primary) / 0.07);
+    --editor-selection: hsl(var(--primary) / 0.22);
+    --syntax-foreground: 268 24% 18%;
+    --syntax-comment: 60 18% 46%;
+    --syntax-string: 45 85% 32%;
+    --syntax-keyword: 330 72% 42%;
+    --syntax-function: 142 58% 30%;
+    --syntax-class: 182 62% 30%;
+    --syntax-constant: 258 60% 50%;
+    --syntax-parameter: 28 82% 40%;
+    --syntax-error: 0 70% 46%;
+    --syntax-tag: 330 72% 42%;
+    --mermaid-primary-color: #f3fcca;
+    --mermaid-primary-text-color: #4b5724;
+    --mermaid-primary-border-color: #c0d163;
+    --mermaid-line-color: #c0d163;
+    --mermaid-secondary-color: #faffe5;
+    --mermaid-tertiary-color: #fdfff4;
+    --mermaid-edge-label-background: #fdfff4;
+  }
+
+  :root[data-color-theme='coral'] {
+    --background: 24 58% 97%;
+    --foreground: 268 24% 18%;
+    --card: 30 100% 99%;
+    --card-foreground: 268 24% 18%;
+    --primary: 29 52% 49%;
+    --primary-foreground: 30 100% 99%;
+    --secondary: 25 50% 92%;
+    --secondary-foreground: 28 28% 28%;
+    --muted: 24 42% 94%;
+    --muted-foreground: 26 14% 44%;
+    --accent: 36 58% 90%;
+    --accent-foreground: 30 31% 27%;
+    --destructive: 353 70% 54%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 27 31% 84%;
+    --input: 27 31% 84%;
+    --ring: 29 52% 49%;
+    --editor-surface: 27 80% 98%;
+    --editor-surface-elevated: 30 100% 99%;
+    --preview-surface: 24 56% 96%;
+    --scrollbar-track: 24 42% 92%;
+    --scrollbar-thumb: 28 31% 74%;
+    --scrollbar-thumb-hover: 29 40% 63%;
+    --scrollbar-corner: 24 42% 92%;
+    --success-soft: 149 48% 92%;
+    --success-foreground: 150 49% 30%;
+    --editor-text: hsl(var(--foreground));
+    --editor-cursor: hsl(var(--primary));
+    --editor-active-line: hsl(var(--primary) / 0.07);
+    --editor-selection: hsl(var(--primary) / 0.22);
+    --syntax-foreground: 268 24% 18%;
+    --syntax-comment: 10 18% 46%;
+    --syntax-string: 45 85% 32%;
+    --syntax-keyword: 330 72% 42%;
+    --syntax-function: 142 58% 30%;
+    --syntax-class: 182 62% 30%;
+    --syntax-constant: 258 60% 50%;
+    --syntax-parameter: 28 82% 40%;
+    --syntax-error: 0 70% 46%;
+    --syntax-tag: 330 72% 42%;
+    --mermaid-primary-color: #fcdbca;
+    --mermaid-primary-text-color: #573824;
+    --mermaid-primary-border-color: #d18663;
+    --mermaid-line-color: #d18663;
+    --mermaid-secondary-color: #ffeee5;
+    --mermaid-tertiary-color: #fff8f4;
+    --mermaid-edge-label-background: #fff8f4;
+  }
+
+  :root[data-color-theme='sapphire'] {
+    --background: 224 58% 97%;
+    --foreground: 268 24% 18%;
+    --card: 230 100% 99%;
+    --card-foreground: 268 24% 18%;
+    --primary: 229 52% 49%;
+    --primary-foreground: 230 100% 99%;
+    --secondary: 225 50% 92%;
+    --secondary-foreground: 228 28% 28%;
+    --muted: 224 42% 94%;
+    --muted-foreground: 226 14% 44%;
+    --accent: 236 58% 90%;
+    --accent-foreground: 230 31% 27%;
+    --destructive: 353 70% 54%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 227 31% 84%;
+    --input: 227 31% 84%;
+    --ring: 229 52% 49%;
+    --editor-surface: 227 80% 98%;
+    --editor-surface-elevated: 230 100% 99%;
+    --preview-surface: 224 56% 96%;
+    --scrollbar-track: 224 42% 92%;
+    --scrollbar-thumb: 228 31% 74%;
+    --scrollbar-thumb-hover: 229 40% 63%;
+    --scrollbar-corner: 224 42% 92%;
+    --success-soft: 149 48% 92%;
+    --success-foreground: 150 49% 30%;
+    --editor-text: hsl(var(--foreground));
+    --editor-cursor: hsl(var(--primary));
+    --editor-active-line: hsl(var(--primary) / 0.07);
+    --editor-selection: hsl(var(--primary) / 0.22);
+    --syntax-foreground: 268 24% 18%;
+    --syntax-comment: 210 18% 46%;
+    --syntax-string: 45 85% 32%;
+    --syntax-keyword: 330 72% 42%;
+    --syntax-function: 142 58% 30%;
+    --syntax-class: 182 62% 30%;
+    --syntax-constant: 258 60% 50%;
+    --syntax-parameter: 28 82% 40%;
+    --syntax-error: 0 70% 46%;
+    --syntax-tag: 330 72% 42%;
+    --mermaid-primary-color: #cadafc;
+    --mermaid-primary-text-color: #243257;
+    --mermaid-primary-border-color: #6389d1;
+    --mermaid-line-color: #6389d1;
+    --mermaid-secondary-color: #e5edff;
+    --mermaid-tertiary-color: #f4f7ff;
+    --mermaid-edge-label-background: #f4f7ff;
+  }
+
+/* ==== DARK THEMES ==== */
+
+  .dark,
+  .dark[data-color-theme='amethyst'] {
+    --background: 245 14% 12%;
+    --foreground: 60 30% 96%;
+    --card: 245 14% 19%;
+    --card-foreground: 60 30% 96%;
+    --primary: 250 100% 75%;
+    --primary-foreground: 250 40% 12%;
+    --secondary: 245 14% 22%;
+    --secondary-foreground: 60 20% 85%;
+    --muted: 245 14% 20%;
+    --muted-foreground: 244 25% 55%;
+    --accent: 245 14% 25%;
+    --accent-foreground: 60 20% 88%;
     --destructive: 353 74% 61%;
     --destructive-foreground: 0 0% 100%;
-    --border: 270 18% 25%;
-    --input: 270 18% 25%;
-    --ring: 269 82% 74%;
-    --editor-surface: 271 31% 11%;
-    --editor-surface-elevated: 273 32% 14%;
-    --preview-surface: 270 27% 10%;
-    --scrollbar-track: 271 22% 16%;
-    --scrollbar-thumb: 270 26% 36%;
-    --scrollbar-thumb-hover: 269 42% 56%;
-    --scrollbar-corner: 271 22% 16%;
+    --border: 245 14% 28%;
+    --input: 245 14% 28%;
+    --ring: 250 100% 75%;
+    --editor-surface: 245 14% 15%;
+    --editor-surface-elevated: 245 14% 18%;
+    --preview-surface: 245 14% 13%;
+    --scrollbar-track: 245 14% 21%;
+    --scrollbar-thumb: 245 14% 35%;
+    --scrollbar-thumb-hover: 250 45% 56%;
+    --scrollbar-corner: 245 14% 21%;
     --success-soft: 151 38% 18%;
     --success-foreground: 149 47% 76%;
     --editor-text: hsl(var(--foreground));
     --editor-cursor: hsl(var(--primary));
-    --editor-active-line: hsl(var(--primary) / 0.1);
-    --editor-selection: hsl(var(--primary) / 0.24);
-    --app-shell-overlay:
-      radial-gradient(
-        circle at top,
-        rgba(150, 112, 235, 0.32),
-        transparent 44%
-      ),
-      linear-gradient(180deg, rgba(58, 38, 104, 0.16), rgba(16, 12, 26, 0.92));
-    --app-grain-opacity: 0.2;
-    --texture-grain: radial-gradient(
-      circle at 1px 1px,
-      rgba(155, 127, 220, 0.08) 1px,
-      transparent 0
-    );
-    --shadow-panel: 0 18px 44px hsl(var(--primary) / 0.2);
+    --editor-active-line: hsl(244 25% 25%);
+    --editor-selection: hsl(245 15% 30%);
+    --syntax-foreground: 60 30% 96%;
+    --syntax-comment: 244 25% 55%;
+    --syntax-string: 60 100% 75%;
+    --syntax-keyword: 330 100% 75%;
+    --syntax-function: 115 100% 75%;
+    --syntax-class: 170 100% 75%;
+    --syntax-constant: 250 100% 75%;
+    --syntax-parameter: 35 100% 75%;
+    --syntax-error: 10 100% 75%;
+    --syntax-tag: 330 100% 75%;
     --mermaid-primary-color: #382553;
     --mermaid-primary-text-color: #eadfff;
     --mermaid-primary-border-color: #b293f4;
@@ -123,6 +410,257 @@
     --mermaid-tertiary-color: #181123;
     --mermaid-edge-label-background: #181123;
   }
+
+  .dark[data-color-theme='rose'] {
+    --background: 289 14% 12%;
+    --foreground: 60 30% 96%;
+    --card: 289 14% 19%;
+    --card-foreground: 60 30% 96%;
+    --primary: 330 100% 75%;
+    --primary-foreground: 330 40% 12%;
+    --secondary: 289 14% 22%;
+    --secondary-foreground: 60 20% 85%;
+    --muted: 289 14% 20%;
+    --muted-foreground: 288 25% 55%;
+    --accent: 289 14% 25%;
+    --accent-foreground: 60 20% 88%;
+    --destructive: 353 74% 61%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 289 14% 28%;
+    --input: 289 14% 28%;
+    --ring: 330 100% 75%;
+    --editor-surface: 289 14% 15%;
+    --editor-surface-elevated: 289 14% 18%;
+    --preview-surface: 289 14% 13%;
+    --scrollbar-track: 289 14% 21%;
+    --scrollbar-thumb: 289 14% 35%;
+    --scrollbar-thumb-hover: 330 45% 56%;
+    --scrollbar-corner: 289 14% 21%;
+    --success-soft: 151 38% 18%;
+    --success-foreground: 149 47% 76%;
+    --editor-text: hsl(var(--foreground));
+    --editor-cursor: hsl(var(--primary));
+    --editor-active-line: hsl(289 25% 25%);
+    --editor-selection: hsl(290 15% 30%);
+    --syntax-foreground: 60 30% 96%;
+    --syntax-comment: 288 25% 55%;
+    --syntax-string: 60 100% 75%;
+    --syntax-keyword: 330 100% 75%;
+    --syntax-function: 115 100% 75%;
+    --syntax-class: 170 100% 75%;
+    --syntax-constant: 250 100% 75%;
+    --syntax-parameter: 35 100% 75%;
+    --syntax-error: 10 100% 75%;
+    --syntax-tag: 330 100% 75%;
+    --mermaid-primary-color: #532530;
+    --mermaid-primary-text-color: #ffdfe9;
+    --mermaid-primary-border-color: #f493b4;
+    --mermaid-line-color: #f493b4;
+    --mermaid-secondary-color: #35181f;
+    --mermaid-tertiary-color: #231116;
+    --mermaid-edge-label-background: #231116;
+  }
+
+  .dark[data-color-theme='jade'] {
+    --background: 169 14% 12%;
+    --foreground: 60 30% 96%;
+    --card: 169 14% 19%;
+    --card-foreground: 60 30% 96%;
+    --primary: 170 100% 75%;
+    --primary-foreground: 170 40% 12%;
+    --secondary: 169 14% 22%;
+    --secondary-foreground: 60 20% 85%;
+    --muted: 169 14% 20%;
+    --muted-foreground: 168 25% 55%;
+    --accent: 169 14% 25%;
+    --accent-foreground: 60 20% 88%;
+    --destructive: 353 74% 61%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 169 14% 28%;
+    --input: 169 14% 28%;
+    --ring: 170 100% 75%;
+    --editor-surface: 169 14% 15%;
+    --editor-surface-elevated: 169 14% 18%;
+    --preview-surface: 169 14% 13%;
+    --scrollbar-track: 169 14% 21%;
+    --scrollbar-thumb: 169 14% 35%;
+    --scrollbar-thumb-hover: 170 45% 56%;
+    --scrollbar-corner: 169 14% 21%;
+    --success-soft: 151 38% 18%;
+    --success-foreground: 149 47% 76%;
+    --editor-text: hsl(var(--foreground));
+    --editor-cursor: hsl(var(--primary));
+    --editor-active-line: hsl(169 25% 25%);
+    --editor-selection: hsl(170 15% 30%);
+    --syntax-foreground: 60 30% 96%;
+    --syntax-comment: 168 25% 55%;
+    --syntax-string: 60 100% 75%;
+    --syntax-keyword: 330 100% 75%;
+    --syntax-function: 115 100% 75%;
+    --syntax-class: 170 100% 75%;
+    --syntax-constant: 250 100% 75%;
+    --syntax-parameter: 35 100% 75%;
+    --syntax-error: 10 100% 75%;
+    --syntax-tag: 330 100% 75%;
+    --mermaid-primary-color: #254f53;
+    --mermaid-primary-text-color: #dfffff;
+    --mermaid-primary-border-color: #93f4f3;
+    --mermaid-line-color: #93f4f3;
+    --mermaid-secondary-color: #183335;
+    --mermaid-tertiary-color: #112223;
+    --mermaid-edge-label-background: #112223;
+  }
+
+  .dark[data-color-theme='amber'] {
+    --background: 49 14% 12%;
+    --foreground: 60 30% 96%;
+    --card: 49 14% 19%;
+    --card-foreground: 60 30% 96%;
+    --primary: 60 100% 75%;
+    --primary-foreground: 60 40% 12%;
+    --secondary: 49 14% 22%;
+    --secondary-foreground: 60 20% 85%;
+    --muted: 49 14% 20%;
+    --muted-foreground: 48 25% 55%;
+    --accent: 49 14% 25%;
+    --accent-foreground: 60 20% 88%;
+    --destructive: 353 74% 61%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 49 14% 28%;
+    --input: 49 14% 28%;
+    --ring: 60 100% 75%;
+    --editor-surface: 49 14% 15%;
+    --editor-surface-elevated: 49 14% 18%;
+    --preview-surface: 49 14% 13%;
+    --scrollbar-track: 49 14% 21%;
+    --scrollbar-thumb: 49 14% 35%;
+    --scrollbar-thumb-hover: 60 45% 56%;
+    --scrollbar-corner: 49 14% 21%;
+    --success-soft: 151 38% 18%;
+    --success-foreground: 149 47% 76%;
+    --editor-text: hsl(var(--foreground));
+    --editor-cursor: hsl(var(--primary));
+    --editor-active-line: hsl(49 25% 25%);
+    --editor-selection: hsl(50 15% 30%);
+    --syntax-foreground: 60 30% 96%;
+    --syntax-comment: 48 25% 55%;
+    --syntax-string: 60 100% 75%;
+    --syntax-keyword: 330 100% 75%;
+    --syntax-function: 115 100% 75%;
+    --syntax-class: 170 100% 75%;
+    --syntax-constant: 250 100% 75%;
+    --syntax-parameter: 35 100% 75%;
+    --syntax-error: 10 100% 75%;
+    --syntax-tag: 330 100% 75%;
+    --mermaid-primary-color: #485325;
+    --mermaid-primary-text-color: #f9ffdf;
+    --mermaid-primary-border-color: #e5f493;
+    --mermaid-line-color: #e5f493;
+    --mermaid-secondary-color: #2e3518;
+    --mermaid-tertiary-color: #1f2311;
+    --mermaid-edge-label-background: #1f2311;
+  }
+
+  .dark[data-color-theme='coral'] {
+    --background: 355 14% 12%;
+    --foreground: 60 30% 96%;
+    --card: 355 14% 19%;
+    --card-foreground: 60 30% 96%;
+    --primary: 10 100% 75%;
+    --primary-foreground: 10 40% 12%;
+    --secondary: 355 14% 22%;
+    --secondary-foreground: 60 20% 85%;
+    --muted: 355 14% 20%;
+    --muted-foreground: 356 25% 55%;
+    --accent: 355 14% 25%;
+    --accent-foreground: 60 20% 88%;
+    --destructive: 353 74% 61%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 355 14% 28%;
+    --input: 355 14% 28%;
+    --ring: 10 100% 75%;
+    --editor-surface: 355 14% 15%;
+    --editor-surface-elevated: 355 14% 18%;
+    --preview-surface: 355 14% 13%;
+    --scrollbar-track: 355 14% 21%;
+    --scrollbar-thumb: 355 14% 35%;
+    --scrollbar-thumb-hover: 10 45% 56%;
+    --scrollbar-corner: 355 14% 21%;
+    --success-soft: 151 38% 18%;
+    --success-foreground: 149 47% 76%;
+    --editor-text: hsl(var(--foreground));
+    --editor-cursor: hsl(var(--primary));
+    --editor-active-line: hsl(356 25% 25%);
+    --editor-selection: hsl(355 15% 30%);
+    --syntax-foreground: 60 30% 96%;
+    --syntax-comment: 356 25% 55%;
+    --syntax-string: 60 100% 75%;
+    --syntax-keyword: 330 100% 75%;
+    --syntax-function: 115 100% 75%;
+    --syntax-class: 170 100% 75%;
+    --syntax-constant: 250 100% 75%;
+    --syntax-parameter: 35 100% 75%;
+    --syntax-error: 10 100% 75%;
+    --syntax-tag: 330 100% 75%;
+    --mermaid-primary-color: #533825;
+    --mermaid-primary-text-color: #ffeadf;
+    --mermaid-primary-border-color: #f4b293;
+    --mermaid-line-color: #f4b293;
+    --mermaid-secondary-color: #352418;
+    --mermaid-tertiary-color: #231811;
+    --mermaid-edge-label-background: #231811;
+  }
+
+  .dark[data-color-theme='sapphire'] {
+    --background: 210 15% 2%;
+    --foreground: 60 30% 96%;
+    --card: 210 15% 9%;
+    --card-foreground: 60 30% 96%;
+    --primary: 210 100% 75%;
+    --primary-foreground: 210 40% 12%;
+    --secondary: 210 15% 12%;
+    --secondary-foreground: 60 20% 85%;
+    --muted: 210 15% 10%;
+    --muted-foreground: 211 25% 55%;
+    --accent: 210 15% 15%;
+    --accent-foreground: 60 20% 88%;
+    --destructive: 353 74% 61%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 210 15% 18%;
+    --input: 210 15% 18%;
+    --ring: 210 100% 75%;
+    --editor-surface: 210 15% 5%;
+    --editor-surface-elevated: 210 15% 8%;
+    --preview-surface: 210 15% 3%;
+    --scrollbar-track: 210 15% 11%;
+    --scrollbar-thumb: 210 15% 25%;
+    --scrollbar-thumb-hover: 210 45% 56%;
+    --scrollbar-corner: 210 15% 11%;
+    --success-soft: 151 38% 18%;
+    --success-foreground: 149 47% 76%;
+    --editor-text: hsl(var(--foreground));
+    --editor-cursor: hsl(var(--primary));
+    --editor-active-line: hsl(210 25% 25%);
+    --editor-selection: hsl(209 15% 30%);
+    --syntax-foreground: 60 30% 96%;
+    --syntax-comment: 211 25% 55%;
+    --syntax-string: 60 100% 75%;
+    --syntax-keyword: 330 100% 75%;
+    --syntax-function: 115 100% 75%;
+    --syntax-class: 170 100% 75%;
+    --syntax-constant: 250 100% 75%;
+    --syntax-parameter: 35 100% 75%;
+    --syntax-error: 10 100% 75%;
+    --syntax-tag: 330 100% 75%;
+    --mermaid-primary-color: #253053;
+    --mermaid-primary-text-color: #dfe9ff;
+    --mermaid-primary-border-color: #93b4f4;
+    --mermaid-line-color: #93b4f4;
+    --mermaid-secondary-color: #181f35;
+    --mermaid-tertiary-color: #111623;
+    --mermaid-edge-label-background: #111623;
+  }
+
 
   * {
     @apply border-border;
@@ -351,5 +889,78 @@
   .preview-prose blockquote {
     @apply rounded-2xl py-1 pr-4;
     background: hsl(var(--secondary) / 0.36);
+  }
+
+  /* Fenced-code syntax highlighting (highlight.js classes -> theme palette). */
+  .preview-prose code.hljs {
+    color: hsl(var(--syntax-foreground));
+  }
+
+  .preview-prose .hljs-comment,
+  .preview-prose .hljs-quote {
+    color: hsl(var(--syntax-comment));
+    font-style: italic;
+  }
+
+  .preview-prose .hljs-keyword,
+  .preview-prose .hljs-selector-tag,
+  .preview-prose .hljs-literal,
+  .preview-prose .hljs-doctag {
+    color: hsl(var(--syntax-keyword));
+  }
+
+  .preview-prose .hljs-string,
+  .preview-prose .hljs-meta .hljs-string,
+  .preview-prose .hljs-regexp {
+    color: hsl(var(--syntax-string));
+  }
+
+  .preview-prose .hljs-title,
+  .preview-prose .hljs-title.function_,
+  .preview-prose .hljs-section {
+    color: hsl(var(--syntax-function));
+  }
+
+  .preview-prose .hljs-type,
+  .preview-prose .hljs-title.class_,
+  .preview-prose .hljs-built_in,
+  .preview-prose .hljs-class .hljs-title {
+    color: hsl(var(--syntax-class));
+  }
+
+  .preview-prose .hljs-number,
+  .preview-prose .hljs-symbol,
+  .preview-prose .hljs-bullet {
+    color: hsl(var(--syntax-constant));
+  }
+
+  .preview-prose .hljs-params,
+  .preview-prose .hljs-attr,
+  .preview-prose .hljs-attribute,
+  .preview-prose .hljs-variable,
+  .preview-prose .hljs-template-variable,
+  .preview-prose .hljs-meta {
+    color: hsl(var(--syntax-parameter));
+  }
+
+  .preview-prose .hljs-name,
+  .preview-prose .hljs-tag {
+    color: hsl(var(--syntax-tag));
+  }
+
+  .preview-prose .hljs-deletion {
+    color: hsl(var(--syntax-error));
+  }
+
+  .preview-prose .hljs-addition {
+    color: hsl(var(--syntax-function));
+  }
+
+  .preview-prose .hljs-emphasis {
+    font-style: italic;
+  }
+
+  .preview-prose .hljs-strong {
+    font-weight: 700;
   }
 }

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -2,6 +2,7 @@ import type { AppSettings } from './types';
 
 export const defaultAppSettings: AppSettings = {
   theme: 'light',
+  colorTheme: 'amethyst',
   language: 'en',
   exportFont: 'system',
   editorFontFamily: 'IBM Plex Mono',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -20,6 +20,14 @@ export type PdfPageSize = 'A4' | 'Letter' | 'Legal' | 'A3';
 
 export type ExportFont = 'system' | 'serif' | 'mono';
 
+export type ThemeName =
+  | 'amethyst'
+  | 'rose'
+  | 'jade'
+  | 'amber'
+  | 'coral'
+  | 'sapphire';
+
 export type PdfMargins = {
   top: number;
   right: number;
@@ -29,6 +37,7 @@ export type PdfMargins = {
 
 export type AppSettings = {
   theme: 'light' | 'dark';
+  colorTheme: ThemeName;
   language: Locale;
   exportFont: ExportFont;
   editorFontFamily: string;

--- a/tests/e2e/theme.test.ts
+++ b/tests/e2e/theme.test.ts
@@ -27,3 +27,42 @@ test.describe('theme switching', () => {
     await window.keyboard.press('Escape');
   });
 });
+
+test.describe('color theme switching', () => {
+  const readColorTheme = (window: import('@playwright/test').Page) =>
+    window.evaluate(() =>
+      document.documentElement.getAttribute('data-color-theme'),
+    );
+
+  test('applies the selected color theme to the document', async ({
+    window,
+  }) => {
+    await window.locator('button[aria-label="Settings"]').click();
+    await window.locator('button:has-text("Jade")').click();
+    expect(await readColorTheme(window)).toBe('jade');
+
+    // Restore default so later tests start from Amethyst.
+    await window.locator('button:has-text("Amethyst")').click();
+    expect(await readColorTheme(window)).toBe('amethyst');
+    await window.keyboard.press('Escape');
+  });
+
+  test('persists the color theme across a reload', async ({ window }) => {
+    await window.locator('button[aria-label="Settings"]').click();
+    await window.locator('button:has-text("Sapphire")').click();
+    await window.keyboard.press('Escape');
+
+    await window.reload();
+    await window.waitForLoadState('domcontentloaded');
+    await window
+      .locator('header')
+      .waitFor({ state: 'visible', timeout: 10_000 });
+
+    expect(await readColorTheme(window)).toBe('sapphire');
+
+    // Restore default.
+    await window.locator('button[aria-label="Settings"]').click();
+    await window.locator('button:has-text("Amethyst")').click();
+    await window.keyboard.press('Escape');
+  });
+});

--- a/tests/unit/settings.test.ts
+++ b/tests/unit/settings.test.ts
@@ -22,6 +22,15 @@ describe('mergeAppSettings', () => {
     expect(result.language).toBe(defaultAppSettings.language);
   });
 
+  it('preserves an explicit colorTheme and defaults it otherwise', () => {
+    expect(mergeAppSettings({ colorTheme: 'sapphire' }).colorTheme).toBe(
+      'sapphire',
+    );
+    expect(mergeAppSettings({ theme: 'dark' }).colorTheme).toBe(
+      defaultAppSettings.colorTheme,
+    );
+  });
+
   it('deep-merges pdfMargins', () => {
     const result = mergeAppSettings({ pdfMargins: { top: 50 } as never });
     expect(result.pdfMargins).toEqual({
@@ -51,5 +60,6 @@ describe('defaultAppSettings', () => {
     expect(defaultAppSettings.editorFontFamily).toBe('IBM Plex Mono');
     expect(defaultAppSettings.previewFontFamily).toBe('IBM Plex Sans');
     expect(defaultAppSettings.pdfPageSize).toBe('A4');
+    expect(defaultAppSettings.colorTheme).toBe('amethyst');
   });
 });

--- a/tests/unit/theme-contrast.test.ts
+++ b/tests/unit/theme-contrast.test.ts
@@ -1,0 +1,112 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Guards issue #3's readability requirement: every palette (light and dark)
+ * must keep body text and syntax tokens legible against its own surfaces,
+ * with the very dark Sapphire background explicitly covered.
+ */
+const css = readFileSync(
+  resolve('src/renderer/src/index.css'),
+  'utf-8',
+);
+
+const THEMES = ['amethyst', 'rose', 'jade', 'amber', 'coral', 'sapphire'];
+const SYNTAX_KEYS = [
+  'syntax-foreground',
+  'syntax-comment',
+  'syntax-string',
+  'syntax-keyword',
+  'syntax-function',
+  'syntax-class',
+  'syntax-constant',
+  'syntax-parameter',
+  'syntax-error',
+  'syntax-tag',
+];
+
+type Rgb = [number, number, number];
+
+function hslTripletToRgb(triplet: string): Rgb {
+  const m = triplet
+    .trim()
+    .match(/^([\d.]+)\s+([\d.]+)%\s+([\d.]+)%$/);
+  if (!m) throw new Error(`not an HSL triplet: "${triplet}"`);
+  const h = parseFloat(m[1]);
+  const s = parseFloat(m[2]) / 100;
+  const l = parseFloat(m[3]) / 100;
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const mm = l - c / 2;
+  let rgb: Rgb = [0, 0, 0];
+  if (h < 60) rgb = [c, x, 0];
+  else if (h < 120) rgb = [x, c, 0];
+  else if (h < 180) rgb = [0, c, x];
+  else if (h < 240) rgb = [0, x, c];
+  else if (h < 300) rgb = [x, 0, c];
+  else rgb = [c, 0, x];
+  return rgb.map((v) => (v + mm) * 255) as Rgb;
+}
+
+function luminance([r, g, b]: Rgb): number {
+  const f = (v: number) => {
+    const n = v / 255;
+    return n <= 0.03928 ? n / 12.92 : ((n + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b);
+}
+
+function contrast(a: Rgb, b: Rgb): number {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+function blockVars(selector: string): Record<string, string> {
+  const idx = css.indexOf(selector);
+  if (idx === -1) throw new Error(`missing CSS block for ${selector}`);
+  const open = css.indexOf('{', idx);
+  const close = css.indexOf('}', open);
+  const vars: Record<string, string> = {};
+  for (const line of css.slice(open + 1, close).split('\n')) {
+    const m = line.match(/--([\w-]+):\s*([^;]+);/);
+    if (m) vars[m[1]] = m[2].trim();
+  }
+  return vars;
+}
+
+function selectorFor(mode: 'light' | 'dark', name: string): string {
+  if (mode === 'dark') {
+    return name === 'amethyst'
+      ? `.dark,\n  .dark[data-color-theme='amethyst']`
+      : `.dark[data-color-theme='${name}']`;
+  }
+  return name === 'amethyst'
+    ? `:root,\n  :root[data-color-theme='amethyst']`
+    : `:root[data-color-theme='${name}']`;
+}
+
+describe('theme contrast (WCAG)', () => {
+  for (const mode of ['light', 'dark'] as const) {
+    for (const name of THEMES) {
+      const vars = blockVars(selectorFor(mode, name));
+
+      it(`${mode}/${name}: body text is legible on the app background`, () => {
+        const fg = hslTripletToRgb(vars.foreground);
+        const bg = hslTripletToRgb(vars.background);
+        expect(contrast(fg, bg)).toBeGreaterThanOrEqual(4.5);
+      });
+
+      it(`${mode}/${name}: syntax tokens are legible on the editor surface`, () => {
+        const surface = hslTripletToRgb(vars['editor-surface']);
+        for (const key of SYNTAX_KEYS) {
+          const token = hslTripletToRgb(vars[key]);
+          expect(
+            contrast(token, surface),
+            `${key} in ${mode}/${name}`,
+          ).toBeGreaterThanOrEqual(3);
+        }
+      });
+    }
+  }
+});

--- a/tests/unit/themes.test.ts
+++ b/tests/unit/themes.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import {
+  THEMES,
+  THEME_NAMES,
+  isThemeName,
+} from '@renderer/features/settings/lib/themes';
+
+describe('theme registry', () => {
+  it('exposes the six issue-defined themes with Amethyst first', () => {
+    expect(THEME_NAMES).toEqual([
+      'amethyst',
+      'rose',
+      'jade',
+      'amber',
+      'coral',
+      'sapphire',
+    ]);
+  });
+
+  it('gives every theme a label and a hex swatch', () => {
+    for (const theme of THEMES) {
+      expect(theme.label).toMatch(/\w/);
+      expect(theme.swatch).toMatch(/^#[0-9a-f]{6}$/i);
+    }
+  });
+
+  it('recognises valid theme names and rejects others', () => {
+    expect(isThemeName('jade')).toBe(true);
+    expect(isThemeName('turquoise')).toBe(false);
+  });
+});


### PR DESCRIPTION
Adds the six color themes from #3 — Amethyst, Rose, Jade, Amber, Coral, Sapphire — and each one works in both light and dark, so 12 palettes in total. It all runs off CSS variables keyed on a `data-color-theme` attribute on the html element, which means the whole app (titlebar, editor, preview) re-tints on its own without any per-theme branching in the code. The issue only spelled out the dark palettes, so I derived the light ones by hue-rotating the existing Amethyst-light theme toward each accent.

Since the themes define syntax token colors, I went ahead and hooked up real syntax highlighting. The editor now highlights markdown and fenced code blocks (including mermaid), and the preview highlights code via rehype-highlight. Exports keep their own plain, static code colors so they stay independent of whatever theme you're using in the app. Your theme choice persists across sessions and there's a picker in settings.

One thing that bit me while testing: mermaid diagrams kept rendering with the previous palette's colors. Turned out React runs child effects before parent ones, so the preview was re-drawing the diagram before the theme attributes actually landed on the html element. Switching the appearance hook to a layout effect fixed it (and killed a small theme flash on load as a bonus).

Also added a contrast test that walks every palette and checks WCAG ratios against its own background — Sapphire's the darkest so it got the closest look, and it's comfortably fine.

Closes #3.