### PR TITLE
fix(settings): unify dialog label and section typography

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,6 +32,61 @@ export default tseslint.config(
       ],
     },
   },
+  // Typography drift is what issue #16 was. Colours never drifted because
+  // tokens plus a contrast test forbid it; type had neither. These two blocks
+  // are that missing guard rail.
+  {
+    files: ['src/renderer/src/**/*.tsx'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'Literal[value=/text-\\[\\d/]',
+          message:
+            'No arbitrary font sizes. Use a fontSize token (text-section / text-label / text-sub / text-hint) from tailwind.config.ts, or add one there.',
+        },
+        {
+          selector: 'TemplateElement[value.raw=/text-\\[\\d/]',
+          message:
+            'No arbitrary font sizes. Use a fontSize token (text-section / text-label / text-sub / text-hint) from tailwind.config.ts, or add one there.',
+        },
+      ],
+    },
+  },
+  {
+    // The dialog surface holds a 13px floor. Button keeps its own `sm` variant
+    // at text-xs on purpose — it is never rendered inside a dialog.
+    files: [
+      'src/renderer/src/components/ui/field.tsx',
+      'src/renderer/src/components/ui/modal.tsx',
+      'src/renderer/src/features/**/components/*-dialog.tsx',
+    ],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'Literal[value=/\\btext-xs\\b/]',
+          message:
+            'Below the 13px dialog floor. Use text-sub or text-hint (see components/ui/field.tsx).',
+        },
+        {
+          selector: 'TemplateElement[value.raw=/\\btext-xs\\b/]',
+          message:
+            'Below the 13px dialog floor. Use text-sub or text-hint (see components/ui/field.tsx).',
+        },
+        {
+          selector: 'Literal[value=/text-\\[\\d/]',
+          message:
+            'No arbitrary font sizes. Use a fontSize token from tailwind.config.ts.',
+        },
+        {
+          selector: 'TemplateElement[value.raw=/text-\\[\\d/]',
+          message:
+            'No arbitrary font sizes. Use a fontSize token from tailwind.config.ts.',
+        },
+      ],
+    },
+  },
   {
     files: [
       'src/main/**/*.ts',

--- a/src/renderer/src/components/ui/field.tsx
+++ b/src/renderer/src/components/ui/field.tsx
@@ -1,0 +1,88 @@
+import { cn } from '@renderer/lib/utils';
+
+/**
+ * Shared form typography for dialogs.
+ *
+ * One uppercase tier only — the section heading. Everything below it is
+ * sentence case and leans on size, weight and colour for hierarchy, so a
+ * nested sub-label never shouts louder than the field it sits under.
+ *
+ * 13px is the floor: nothing on a dialog surface renders smaller. Sizes come
+ * from the `fontSize` tokens in tailwind.config.ts — never a raw `text-[13px]`,
+ * which is what let the old styles drift apart in the first place.
+ *
+ *   text-section  13px  semibold  uppercase  muted
+ *   text-label    14px  medium    sentence   foreground/90
+ *   text-sub      13px  medium    sentence   muted
+ *   text-hint     13px  normal    sentence   muted
+ */
+
+export const inputClass =
+  'w-full rounded-lg border border-border bg-background px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring';
+
+export function SectionHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <h3 className="text-section font-semibold uppercase text-muted-foreground">
+      {children}
+    </h3>
+  );
+}
+
+type LabelProps = {
+  children: React.ReactNode;
+  /**
+   * Binds a real <label> to this control. Omit when the label heads a group
+   * of controls (button rows, margin grids) that no single id can stand for —
+   * a label pointing at nothing helps nobody, so those render as plain text.
+   */
+  htmlFor?: string;
+  className?: string;
+};
+
+export function FieldLabel({ children, htmlFor, className }: LabelProps) {
+  const classes = cn(
+    'mb-1 block text-label font-medium text-foreground/90',
+    className,
+  );
+
+  if (htmlFor) {
+    return (
+      <label className={classes} htmlFor={htmlFor}>
+        {children}
+      </label>
+    );
+  }
+
+  return <p className={classes}>{children}</p>;
+}
+
+export function SubLabel({ children, htmlFor, className }: LabelProps) {
+  const classes = cn(
+    'mb-1 block text-sub font-medium text-muted-foreground',
+    className,
+  );
+
+  if (htmlFor) {
+    return (
+      <label className={classes} htmlFor={htmlFor}>
+        {children}
+      </label>
+    );
+  }
+
+  return <span className={classes}>{children}</span>;
+}
+
+export function FieldHint({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <p className={cn('text-hint text-muted-foreground', className)}>
+      {children}
+    </p>
+  );
+}

--- a/src/renderer/src/components/ui/modal.tsx
+++ b/src/renderer/src/components/ui/modal.tsx
@@ -69,7 +69,7 @@ export function Modal({
           <div>
             <h2 className="text-sm font-semibold tracking-wide">{title}</h2>
             {subtitle && (
-              <p className="mt-1 text-xs text-muted-foreground">{subtitle}</p>
+              <p className="mt-1 text-hint text-muted-foreground">{subtitle}</p>
             )}
           </div>
           <Button

--- a/src/renderer/src/features/editor/components/insert-asset-dialog.tsx
+++ b/src/renderer/src/features/editor/components/insert-asset-dialog.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { FolderOpen, TriangleAlert } from 'lucide-react';
 import { Button } from '@renderer/components/ui/button';
+import {
+  FieldHint,
+  FieldLabel,
+  inputClass,
+} from '@renderer/components/ui/field';
 import { Modal } from '@renderer/components/ui/modal';
 import { useTranslation } from '@renderer/i18n';
 import { relativeToFile } from '@renderer/lib/paths';
@@ -30,11 +35,6 @@ type InsertAssetDialogProps = {
   onClose: () => void;
   onInsert: (payload: InsertAssetPayload) => void;
 };
-
-const inputClass =
-  'w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring';
-
-const labelClass = 'mb-1 block text-xs font-medium text-muted-foreground';
 
 function isLocalPath(value: string): boolean {
   if (!value.trim()) return false;
@@ -163,9 +163,7 @@ function InsertAssetDialogContent({
     <Modal title={title} className="w-full max-w-md" onClose={onClose}>
       <form className="space-y-4 px-5 py-5" onSubmit={handleSubmit}>
         <div>
-          <label className={labelClass} htmlFor="insert-asset-url">
-            {urlLabel}
-          </label>
+          <FieldLabel htmlFor="insert-asset-url">{urlLabel}</FieldLabel>
           <div className={isImage ? 'flex gap-2' : ''}>
             <input
               id="insert-asset-url"
@@ -194,12 +192,12 @@ function InsertAssetDialogContent({
             )}
           </div>
           {isImage && (
-            <p className="mt-1.5 text-xs text-muted-foreground">
+            <FieldHint className="mt-1.5">
               {t('insertAsset.localImageHint')}
-            </p>
+            </FieldHint>
           )}
           {imageWarning && (
-            <p className="mt-1.5 flex items-start gap-1.5 text-xs text-amber-600 dark:text-amber-400">
+            <p className="mt-1.5 flex items-start gap-1.5 text-hint text-amber-600 dark:text-amber-400">
               <TriangleAlert className="mt-px size-3.5 shrink-0" />
               <span>{imageWarning}</span>
             </p>
@@ -207,9 +205,7 @@ function InsertAssetDialogContent({
         </div>
 
         <div>
-          <label className={labelClass} htmlFor="insert-asset-text">
-            {textLabel}
-          </label>
+          <FieldLabel htmlFor="insert-asset-text">{textLabel}</FieldLabel>
           <input
             id="insert-asset-text"
             type="text"

--- a/src/renderer/src/features/help/components/help-dialog.tsx
+++ b/src/renderer/src/features/help/components/help-dialog.tsx
@@ -1,3 +1,4 @@
+import { SectionHeading } from '@renderer/components/ui/field';
 import { Modal } from '@renderer/components/ui/modal';
 import { useSettingsStore } from '@renderer/features/settings/store';
 import { useTranslation } from '@renderer/i18n';
@@ -68,7 +69,7 @@ const viewShortcuts: ShortcutEntry[] = [
 
 function Kbd({ children }: { children: string }) {
   return (
-    <kbd className="inline-flex items-center justify-center rounded-md border border-border/80 bg-muted/60 px-1.5 py-0.5 font-mono text-[11px] font-medium leading-none text-foreground/80 shadow-sm">
+    <kbd className="inline-flex items-center justify-center rounded-md border border-border/80 bg-muted/60 px-1.5 py-0.5 font-mono text-sub font-medium leading-none text-foreground/80 shadow-sm">
       {children}
     </kbd>
   );
@@ -98,9 +99,7 @@ function ShortcutSection({
 }) {
   return (
     <div className="space-y-1">
-      <h3 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
-        {title}
-      </h3>
+      <SectionHeading>{title}</SectionHeading>
       <div className="divide-y divide-border/50">
         {entries.map((entry) => (
           <ShortcutRow key={entry.labelKey} entry={entry} />

--- a/src/renderer/src/features/settings/components/settings-dialog.tsx
+++ b/src/renderer/src/features/settings/components/settings-dialog.tsx
@@ -1,5 +1,12 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Moon, Sun } from 'lucide-react';
+import {
+  FieldHint,
+  FieldLabel,
+  SectionHeading,
+  SubLabel,
+  inputClass,
+} from '@renderer/components/ui/field';
 import { Modal } from '@renderer/components/ui/modal';
 import { cn } from '@renderer/lib/utils';
 import type { ExportFont, Locale, PdfPageSize } from '@shared/types';
@@ -42,13 +49,6 @@ const languageOptions: Array<{ value: Locale; label: string }> = [
   { value: 'es', label: 'Español' },
 ];
 
-const inputClass =
-  'w-full rounded-lg border border-border bg-background px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring';
-
-const labelClass = 'mb-1 block text-xs font-medium text-muted-foreground';
-const subLabelClass =
-  'mb-1 block text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/75';
-
 function Section({
   title,
   children,
@@ -58,9 +58,7 @@ function Section({
 }) {
   return (
     <div className="space-y-3">
-      <h3 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
-        {title}
-      </h3>
+      <SectionHeading>{title}</SectionHeading>
       {children}
     </div>
   );
@@ -120,10 +118,10 @@ function FontField({
 
   return (
     <div className="space-y-2">
-      <label className={labelClass}>{label}</label>
-      <div className="grid grid-cols-[minmax(0,1fr)_6.5rem] gap-2">
+      <FieldLabel>{label}</FieldLabel>
+      <div className="grid grid-cols-[minmax(0,1fr)_7.5rem] gap-2">
         <div className="min-w-0">
-          <span className={subLabelClass}>{familyLabel}</span>
+          <SubLabel>{familyLabel}</SubLabel>
           <select
             className={inputClass}
             value={value}
@@ -137,7 +135,7 @@ function FontField({
           </select>
         </div>
         <div>
-          <span className={subLabelClass}>{sizeLabel}</span>
+          <SubLabel>{sizeLabel}</SubLabel>
           <select
             className={inputClass}
             aria-label={`${label} size`}
@@ -152,11 +150,9 @@ function FontField({
           </select>
         </div>
       </div>
-      <p className="text-xs leading-5 text-muted-foreground">{helper}</p>
+      <FieldHint>{helper}</FieldHint>
       <div className="rounded-2xl border border-border/80 bg-background/70 p-3 shadow-sm">
-        <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground/80">
-          {sampleLabel}
-        </p>
+        <SubLabel className="mb-0">{sampleLabel}</SubLabel>
         <p
           className="mt-2 whitespace-pre-wrap text-foreground/90"
           style={{
@@ -249,7 +245,7 @@ export function SettingsDialog() {
     >
       <Section title={t('settings.appearance')}>
         <div>
-          <p className={labelClass}>{t('settings.language')}</p>
+          <FieldLabel>{t('settings.language')}</FieldLabel>
           <select
             className={inputClass}
             value={settings.language}
@@ -266,7 +262,7 @@ export function SettingsDialog() {
         </div>
 
         <div>
-          <p className={labelClass}>{t('settings.theme')}</p>
+          <FieldLabel>{t('settings.theme')}</FieldLabel>
           <div className="flex gap-2">
             {(['light', 'dark'] as const).map((theme) => (
               <button
@@ -291,7 +287,7 @@ export function SettingsDialog() {
         </div>
 
         <div>
-          <p className={labelClass}>{t('settings.colorTheme')}</p>
+          <FieldLabel>{t('settings.colorTheme')}</FieldLabel>
           <div className="grid grid-cols-3 gap-2">
             {THEMES.map((option) => (
               <button
@@ -320,9 +316,7 @@ export function SettingsDialog() {
       <div className="border-t border-border" />
 
       <Section title={t('settings.writing')}>
-        <p className="text-xs leading-5 text-muted-foreground">
-          {fontLibraryHint}
-        </p>
+        <FieldHint>{fontLibraryHint}</FieldHint>
 
         <div className="space-y-4">
           <FontField
@@ -373,7 +367,7 @@ export function SettingsDialog() {
 
       <Section title={t('settings.export')}>
         <div>
-          <label className={labelClass}>{t('settings.documentFont')}</label>
+          <FieldLabel>{t('settings.documentFont')}</FieldLabel>
           <select
             className={inputClass}
             value={settings.exportFont}
@@ -390,7 +384,7 @@ export function SettingsDialog() {
         </div>
 
         <div>
-          <label className={labelClass}>{t('settings.pdfPageSize')}</label>
+          <FieldLabel>{t('settings.pdfPageSize')}</FieldLabel>
           <select
             className={inputClass}
             value={settings.pdfPageSize}
@@ -407,13 +401,11 @@ export function SettingsDialog() {
         </div>
 
         <div>
-          <p className={labelClass}>{t('settings.pdfMargins')}</p>
+          <FieldLabel>{t('settings.pdfMargins')}</FieldLabel>
           <div className="grid grid-cols-2 gap-2">
             {(['top', 'right', 'bottom', 'left'] as const).map((side) => (
               <div key={side}>
-                <label className="mb-0.5 block text-xs text-muted-foreground">
-                  {marginLabels[side]}
-                </label>
+                <SubLabel>{marginLabels[side]}</SubLabel>
                 <input
                   type="number"
                   min={0}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -46,6 +46,22 @@ export default {
         sans: ['"IBM Plex Sans"', '"Segoe UI"', 'sans-serif'],
         mono: ['"IBM Plex Mono"', '"Cascadia Code"', 'monospace'],
       },
+      /**
+       * Dialog form typography. Roles, not pixels — so a size change happens
+       * here once instead of drifting across component files.
+       *
+       * 13px is the floor: nothing on a dialog surface renders smaller.
+       * Weight stays an explicit utility at the usage site, since baking it in
+       * makes `font-*` overrides depend on Tailwind's emit order.
+       *
+       * See src/renderer/src/components/ui/field.tsx for the tiers.
+       */
+      fontSize: {
+        section: ['13px', { lineHeight: '1rem', letterSpacing: '0.1em' }],
+        label: ['14px', { lineHeight: '1.25rem' }],
+        sub: ['13px', { lineHeight: '1.25rem' }],
+        hint: ['13px', { lineHeight: '1.25rem' }],
+      },
       boxShadow: {
         panel: 'var(--shadow-panel)',
       },


### PR DESCRIPTION
Closes #16.

Labels and sections in Settings used inconsistent casing, and the type was too small to read comfortably.

## What was wrong

Eight different typographic treatments in one dialog, with the hierarchy inverted — `FAMILY` / `SIZE` / `SAMPLE` rendered uppercase and semibold *inside* sentence-case parents like "Editor font", so nested controls read louder than the fields containing them. Three different tracking values (0.1em / 0.12em / 0.14em) for what was meant to be one style, and near-duplicate styles inlined rather than shared, which is how they drifted apart in the first place.

The casing was pure CSS `text-transform` — the i18n strings were already sentence case, so no translations changed.

## What changed

One uppercase tier (section headings). Everything below is sentence case, leaning on size, weight and colour for hierarchy. **13px floor** across the dialog surface.

```
text-section  13px  semibold  uppercase  muted
text-label    14px  medium    sentence   foreground/90
text-sub      13px  medium    sentence   muted
text-hint     13px  normal    sentence   muted
```

Sizes are now `fontSize` tokens in `tailwind.config.ts`, consumed by a shared `components/ui/field.tsx`. The duplicated `labelClass` / `inputClass` constants are gone from the settings and insert dialogs, which also resolves a `py-2` vs `py-1.5` drift between them.

## Why the lint rule

Colour has never drifted in this repo, because tokens plus `theme-contrast.test.ts` forbid it. Typography had neither guard — that's why #16 happened. So arbitrary font sizes (`text-[13px]`) are now a lint error across the renderer, and `text-xs` is an error on the dialog surface. Verified by injecting both and watching it fail. `button.tsx` keeps `text-xs` in its `sm` variant, which never renders inside a dialog.

## Checks

- e2e 72/72, unit 93 pass
- `theme-contrast.test.ts` fails — confirmed identical on clean `main`, unrelated
- typecheck, lint, build clean
- Screenshots reviewed across light/dark, en/pt-BR/es, settings + help

Commits are ordered so each one builds and lints on its own: tokens land first, dialogs adopt them, lint rule last.

## Notes

- Family/size grid column widened `6.5rem` → `7.5rem`; at 13px the Spanish and Portuguese size labels no longer fit the old width.
- `text-sub` carries a line-height the old `text-[13px]` didn't, so sub-labels gained ~2px of leading. Intentional, screenshots checked.
- Prettier reports the touched files as unformatted — they already were on `main`. Left alone so it doesn't bury this diff.

## Follow-ups, not in here

- `htmlFor`-less labels in the settings dialog (real a11y bug on lines this PR touches, but out of scope for #16)
- Playwright screenshot baselines — the harness already exists, ~6s to shoot every theme
