### PR TITLE
fix(a11y): bind settings labels and fix dialog accessibility

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -26,7 +26,29 @@ import {
   insertLink,
 } from '@renderer/features/editor/lib/toolbar-actions';
 import { useScrollSync } from '@renderer/features/editor/hooks/use-scroll-sync';
-import { I18nProvider } from '@renderer/i18n';
+import {
+  I18nProvider,
+  useTranslation,
+  type TranslationKeys,
+} from '@renderer/i18n';
+
+/**
+ * A named landmark region.
+ *
+ * Separate component because App renders the I18nProvider, so it sits outside
+ * its own context and would always translate against the default locale.
+ */
+function LabelledRegion({
+  labelKey,
+  ref,
+  ...props
+}: React.HTMLAttributes<HTMLElement> & {
+  labelKey: keyof TranslationKeys;
+  ref?: React.Ref<HTMLElement>;
+}) {
+  const { t } = useTranslation();
+  return <section ref={ref} aria-label={t(labelKey)} {...props} />;
+}
 
 export function App() {
   const previewRef = useRef<HTMLDivElement | null>(null);
@@ -137,7 +159,8 @@ export function App() {
 
           <main className="flex flex-1 overflow-hidden">
             {viewMode !== 'preview' && (
-              <section
+              <LabelledRegion
+                labelKey="region.editor"
                 className={cn(
                   'app-editor-pane',
                   viewMode === 'split' && 'border-r border-border/80',
@@ -151,11 +174,12 @@ export function App() {
                     editorViewRef.current = view;
                   }}
                 />
-              </section>
+              </LabelledRegion>
             )}
 
             {viewMode !== 'editor' && (
-              <section
+              <LabelledRegion
+                labelKey="region.preview"
                 ref={previewRef}
                 className="app-preview-pane focus:outline-none"
                 tabIndex={-1}
@@ -166,7 +190,7 @@ export function App() {
                     documentPath={activeDocument.path}
                   />
                 </div>
-              </section>
+              </LabelledRegion>
             )}
           </main>
 

--- a/src/renderer/src/components/ui/field.tsx
+++ b/src/renderer/src/components/ui/field.tsx
@@ -34,12 +34,14 @@ type LabelProps = {
    * Binds a real <label> to this control. Omit when the label heads a group
    * of controls (button rows, margin grids) that no single id can stand for —
    * a label pointing at nothing helps nobody, so those render as plain text.
+   * Give those an `id` instead and point the group's `aria-labelledby` at it.
    */
   htmlFor?: string;
+  id?: string;
   className?: string;
 };
 
-export function FieldLabel({ children, htmlFor, className }: LabelProps) {
+export function FieldLabel({ children, htmlFor, id, className }: LabelProps) {
   const classes = cn(
     'mb-1 block text-label font-medium text-foreground/90',
     className,
@@ -47,16 +49,20 @@ export function FieldLabel({ children, htmlFor, className }: LabelProps) {
 
   if (htmlFor) {
     return (
-      <label className={classes} htmlFor={htmlFor}>
+      <label className={classes} htmlFor={htmlFor} id={id}>
         {children}
       </label>
     );
   }
 
-  return <p className={classes}>{children}</p>;
+  return (
+    <p className={classes} id={id}>
+      {children}
+    </p>
+  );
 }
 
-export function SubLabel({ children, htmlFor, className }: LabelProps) {
+export function SubLabel({ children, htmlFor, id, className }: LabelProps) {
   const classes = cn(
     'mb-1 block text-sub font-medium text-muted-foreground',
     className,
@@ -64,13 +70,17 @@ export function SubLabel({ children, htmlFor, className }: LabelProps) {
 
   if (htmlFor) {
     return (
-      <label className={classes} htmlFor={htmlFor}>
+      <label className={classes} htmlFor={htmlFor} id={id}>
         {children}
       </label>
     );
   }
 
-  return <span className={classes}>{children}</span>;
+  return (
+    <span className={classes} id={id}>
+      {children}
+    </span>
+  );
 }
 
 export function FieldHint({

--- a/src/renderer/src/components/ui/field.tsx
+++ b/src/renderer/src/components/ui/field.tsx
@@ -38,10 +38,26 @@ type LabelProps = {
    */
   htmlFor?: string;
   id?: string;
+  /**
+   * Set on a label that names a group through `aria-labelledby`. The group
+   * already carries the text as its accessible name, so leaving the label in
+   * the tree as well makes screen readers say it twice — once as loose text,
+   * then again on entering the group.
+   *
+   * Safe to hide: the accessible name computation still reads hidden elements
+   * referenced by `aria-labelledby`.
+   */
+  'aria-hidden'?: boolean;
   className?: string;
 };
 
-export function FieldLabel({ children, htmlFor, id, className }: LabelProps) {
+export function FieldLabel({
+  children,
+  htmlFor,
+  id,
+  className,
+  'aria-hidden': ariaHidden,
+}: LabelProps) {
   const classes = cn(
     'mb-1 block text-label font-medium text-foreground/90',
     className,
@@ -56,7 +72,7 @@ export function FieldLabel({ children, htmlFor, id, className }: LabelProps) {
   }
 
   return (
-    <p className={classes} id={id}>
+    <p className={classes} id={id} aria-hidden={ariaHidden}>
       {children}
     </p>
   );

--- a/src/renderer/src/components/ui/modal.tsx
+++ b/src/renderer/src/components/ui/modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useId, useRef } from 'react';
 import { X } from 'lucide-react';
 import { Button } from '@renderer/components/ui/button';
 import { cn } from '@renderer/lib/utils';
@@ -20,9 +20,21 @@ type ModalProps = {
   children: React.ReactNode;
 };
 
+const FOCUSABLE = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
 /**
  * Dialog shell: backdrop, Escape and close button. Callers render only when
  * their dialog is open, so this mounts and unmounts with it.
+ *
+ * Focus is trapped while open and restored to whatever opened the dialog on
+ * close, so keyboard users are not dropped back at the top of the document.
  */
 export function Modal({
   title,
@@ -35,15 +47,66 @@ export function Modal({
 }: ModalProps) {
   const { t } = useTranslation();
   const scrollAreaRef = useRef<HTMLDivElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const headingId = useId();
+  const subtitleId = useId();
+
+  /**
+   * Captured during the first render, deliberately not in an effect: effects
+   * run child-before-parent, and this component's own focus effect runs before
+   * one declared later, so by the time any effect here fires the opener has
+   * already been replaced by something inside the dialog.
+   */
+  const openerRef = useRef<Element | null>(null);
+  openerRef.current ??= document.activeElement;
 
   useEffect(() => {
     scrollAreaRef.current?.focus();
+  }, []);
+
+  // Return focus to whatever opened the dialog once it unmounts.
+  useEffect(() => {
+    return () => {
+      const opener = openerRef.current;
+      if (opener instanceof HTMLElement && opener.isConnected) {
+        opener.focus();
+      }
+    };
   }, []);
 
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
       if (event.key === 'Escape') {
         onClose();
+        return;
+      }
+
+      if (event.key !== 'Tab' || !panelRef.current) {
+        return;
+      }
+
+      const focusable = Array.from(
+        panelRef.current.querySelectorAll<HTMLElement>(FOCUSABLE),
+      ).filter((element) => element.offsetParent !== null);
+
+      if (focusable.length === 0) {
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+
+      // Wrap at the ends, and pull focus back in if it escaped the panel.
+      if (
+        event.shiftKey &&
+        (active === first || !panelRef.current.contains(active))
+      ) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault();
+        first.focus();
       }
     }
 
@@ -58,6 +121,11 @@ export function Modal({
       style={noDrag}
     >
       <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={headingId}
+        aria-describedby={subtitle ? subtitleId : undefined}
         className={cn(
           'relative flex max-h-[calc(100vh-1.5rem)] max-w-[calc(100vw-1.5rem)] flex-col overflow-hidden rounded-2xl border border-border bg-card shadow-2xl',
           className,
@@ -67,9 +135,16 @@ export function Modal({
       >
         <div className="flex items-center justify-between border-b border-border px-5 py-4">
           <div>
-            <h2 className="text-sm font-semibold tracking-wide">{title}</h2>
+            <h2 id={headingId} className="text-sm font-semibold tracking-wide">
+              {title}
+            </h2>
             {subtitle && (
-              <p className="mt-1 text-hint text-muted-foreground">{subtitle}</p>
+              <p
+                id={subtitleId}
+                className="mt-1 text-hint text-muted-foreground"
+              >
+                {subtitle}
+              </p>
             )}
           </div>
           <Button

--- a/src/renderer/src/features/settings/components/settings-dialog.tsx
+++ b/src/renderer/src/features/settings/components/settings-dialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useId, useMemo, useState } from 'react';
 import { Moon, Sun } from 'lucide-react';
 import {
   FieldHint,
@@ -115,14 +115,23 @@ function FontField({
   onFontSizeChange: (value: number) => void;
 }) {
   const availableFontSizes = ensureSelectedFontSize(fontSizeOptions, fontSize);
+  // Rendered once per font, so the ids have to be unique per instance.
+  const fieldId = useId();
+  const familyId = `${fieldId}-family`;
+  const sizeId = `${fieldId}-size`;
 
   return (
-    <div className="space-y-2">
-      <FieldLabel>{label}</FieldLabel>
+    <div
+      className="space-y-2"
+      role="group"
+      aria-labelledby={`${fieldId}-label`}
+    >
+      <FieldLabel id={`${fieldId}-label`}>{label}</FieldLabel>
       <div className="grid grid-cols-[minmax(0,1fr)_7.5rem] gap-2">
         <div className="min-w-0">
-          <SubLabel>{familyLabel}</SubLabel>
+          <SubLabel htmlFor={familyId}>{familyLabel}</SubLabel>
           <select
+            id={familyId}
             className={inputClass}
             value={value}
             onChange={(event) => onChange(event.target.value)}
@@ -135,8 +144,9 @@ function FontField({
           </select>
         </div>
         <div>
-          <SubLabel>{sizeLabel}</SubLabel>
+          <SubLabel htmlFor={sizeId}>{sizeLabel}</SubLabel>
           <select
+            id={sizeId}
             className={inputClass}
             aria-label={`${label} size`}
             value={fontSize}
@@ -245,8 +255,11 @@ export function SettingsDialog() {
     >
       <Section title={t('settings.appearance')}>
         <div>
-          <FieldLabel>{t('settings.language')}</FieldLabel>
+          <FieldLabel htmlFor="settings-language">
+            {t('settings.language')}
+          </FieldLabel>
           <select
+            id="settings-language"
             className={inputClass}
             value={settings.language}
             onChange={(event) =>
@@ -367,8 +380,11 @@ export function SettingsDialog() {
 
       <Section title={t('settings.export')}>
         <div>
-          <FieldLabel>{t('settings.documentFont')}</FieldLabel>
+          <FieldLabel htmlFor="settings-export-font">
+            {t('settings.documentFont')}
+          </FieldLabel>
           <select
+            id="settings-export-font"
             className={inputClass}
             value={settings.exportFont}
             onChange={(event) =>
@@ -384,8 +400,11 @@ export function SettingsDialog() {
         </div>
 
         <div>
-          <FieldLabel>{t('settings.pdfPageSize')}</FieldLabel>
+          <FieldLabel htmlFor="settings-pdf-page-size">
+            {t('settings.pdfPageSize')}
+          </FieldLabel>
           <select
+            id="settings-pdf-page-size"
             className={inputClass}
             value={settings.pdfPageSize}
             onChange={(event) =>
@@ -405,8 +424,11 @@ export function SettingsDialog() {
           <div className="grid grid-cols-2 gap-2">
             {(['top', 'right', 'bottom', 'left'] as const).map((side) => (
               <div key={side}>
-                <SubLabel>{marginLabels[side]}</SubLabel>
+                <SubLabel htmlFor={`settings-margin-${side}`}>
+                  {marginLabels[side]}
+                </SubLabel>
                 <input
+                  id={`settings-margin-${side}`}
                   type="number"
                   min={0}
                   max={100}

--- a/src/renderer/src/features/settings/components/settings-dialog.tsx
+++ b/src/renderer/src/features/settings/components/settings-dialog.tsx
@@ -275,12 +275,20 @@ export function SettingsDialog() {
         </div>
 
         <div>
-          <FieldLabel>{t('settings.theme')}</FieldLabel>
-          <div className="flex gap-2">
+          <FieldLabel id="settings-theme-label">
+            {t('settings.theme')}
+          </FieldLabel>
+          <div
+            className="flex gap-2"
+            role="group"
+            aria-labelledby="settings-theme-label"
+          >
             {(['light', 'dark'] as const).map((theme) => (
               <button
                 key={theme}
+                type="button"
                 onClick={() => updateSettings({ theme })}
+                aria-pressed={settings.theme === theme}
                 className={cn(
                   'flex flex-1 items-center justify-center gap-2 rounded-xl border py-2 text-sm font-medium transition-colors',
                   settings.theme === theme
@@ -300,8 +308,14 @@ export function SettingsDialog() {
         </div>
 
         <div>
-          <FieldLabel>{t('settings.colorTheme')}</FieldLabel>
-          <div className="grid grid-cols-3 gap-2">
+          <FieldLabel id="settings-color-theme-label">
+            {t('settings.colorTheme')}
+          </FieldLabel>
+          <div
+            className="grid grid-cols-3 gap-2"
+            role="group"
+            aria-labelledby="settings-color-theme-label"
+          >
             {THEMES.map((option) => (
               <button
                 key={option.name}
@@ -420,8 +434,14 @@ export function SettingsDialog() {
         </div>
 
         <div>
-          <FieldLabel>{t('settings.pdfMargins')}</FieldLabel>
-          <div className="grid grid-cols-2 gap-2">
+          <FieldLabel id="settings-pdf-margins-label">
+            {t('settings.pdfMargins')}
+          </FieldLabel>
+          <div
+            className="grid grid-cols-2 gap-2"
+            role="group"
+            aria-labelledby="settings-pdf-margins-label"
+          >
             {(['top', 'right', 'bottom', 'left'] as const).map((side) => (
               <div key={side}>
                 <SubLabel htmlFor={`settings-margin-${side}`}>

--- a/src/renderer/src/features/settings/components/settings-dialog.tsx
+++ b/src/renderer/src/features/settings/components/settings-dialog.tsx
@@ -126,7 +126,7 @@ function FontField({
       role="group"
       aria-labelledby={`${fieldId}-label`}
     >
-      <FieldLabel id={`${fieldId}-label`}>{label}</FieldLabel>
+      <FieldLabel id={`${fieldId}-label`} aria-hidden>{label}</FieldLabel>
       <div className="grid grid-cols-[minmax(0,1fr)_7.5rem] gap-2">
         <div className="min-w-0">
           <SubLabel htmlFor={familyId}>{familyLabel}</SubLabel>
@@ -275,7 +275,7 @@ export function SettingsDialog() {
         </div>
 
         <div>
-          <FieldLabel id="settings-theme-label">
+          <FieldLabel id="settings-theme-label" aria-hidden>
             {t('settings.theme')}
           </FieldLabel>
           <div
@@ -308,7 +308,7 @@ export function SettingsDialog() {
         </div>
 
         <div>
-          <FieldLabel id="settings-color-theme-label">
+          <FieldLabel id="settings-color-theme-label" aria-hidden>
             {t('settings.colorTheme')}
           </FieldLabel>
           <div
@@ -434,7 +434,7 @@ export function SettingsDialog() {
         </div>
 
         <div>
-          <FieldLabel id="settings-pdf-margins-label">
+          <FieldLabel id="settings-pdf-margins-label" aria-hidden>
             {t('settings.pdfMargins')}
           </FieldLabel>
           <div

--- a/src/renderer/src/features/workspace/components/document-status.tsx
+++ b/src/renderer/src/features/workspace/components/document-status.tsx
@@ -21,18 +21,29 @@ export function DocumentStatus() {
     <div className="flex items-center gap-4 pr-2 text-sm text-muted-foreground">
       <span>{t('status.words', { count: stats.words })}</span>
       <span>{t('status.characters', { count: stats.characters })}</span>
-      {notice && (
-        <span
-          className={cn(
-            'notice-pill',
-            notice.tone === 'success' && 'notice-pill-success',
-            notice.tone === 'error' && 'notice-pill-error',
-            notice.tone === 'info' && 'notice-pill-info',
-          )}
-        >
-          {notice.message}
-        </span>
-      )}
+      {/*
+        Always rendered, even when empty: a live region has to be in the
+        document before its content changes, otherwise the message that
+        creates it is the one nobody hears.
+
+        Polite for every tone, including errors. These are transient
+        confirmations that clear themselves after a moment, so interrupting
+        whatever the user is reading costs more than it conveys.
+      */}
+      <span role="status" aria-live="polite">
+        {notice && (
+          <span
+            className={cn(
+              'notice-pill',
+              notice.tone === 'success' && 'notice-pill-success',
+              notice.tone === 'error' && 'notice-pill-error',
+              notice.tone === 'info' && 'notice-pill-info',
+            )}
+          >
+            {notice.message}
+          </span>
+        )}
+      </span>
       <Eye className="size-4" />
     </div>
   );

--- a/src/renderer/src/i18n/en.ts
+++ b/src/renderer/src/i18n/en.ts
@@ -57,6 +57,10 @@ export const en: TranslationKeys = {
   'titlebar.settings': 'Settings',
   'titlebar.keyboardShortcuts': 'Keyboard shortcuts',
   'titlebar.close': 'Close',
+
+  // Landmark regions
+  'region.editor': 'Editor',
+  'region.preview': 'Preview',
   'titlebar.removeRecent': 'Remove {name} from recent files',
   'titlebar.minimize': 'Minimize',
   'titlebar.maximize': 'Maximize',

--- a/src/renderer/src/i18n/es.ts
+++ b/src/renderer/src/i18n/es.ts
@@ -57,6 +57,10 @@ export const es: TranslationKeys = {
   'titlebar.settings': 'Configuración',
   'titlebar.keyboardShortcuts': 'Atajos de teclado',
   'titlebar.close': 'Cerrar',
+
+  // Landmark regions
+  'region.editor': 'Editor',
+  'region.preview': 'Vista previa',
   'titlebar.removeRecent': 'Quitar {name} de los archivos recientes',
   'titlebar.minimize': 'Minimizar',
   'titlebar.maximize': 'Maximizar',

--- a/src/renderer/src/i18n/i18n-context.tsx
+++ b/src/renderer/src/i18n/i18n-context.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useMemo } from 'react';
+import { createContext, useContext, useEffect, useMemo } from 'react';
 import type { Locale } from '@shared/types';
 import type { TranslationKeys } from './types';
 import { en } from './en';
@@ -71,6 +71,12 @@ export function I18nProvider({
       t: (key, vars) => translate(dict, key, vars),
       locale,
     };
+  }, [locale]);
+
+  // index.html ships lang="en"; without this the document keeps claiming
+  // English and screen readers read pt-BR and es with English phonetics.
+  useEffect(() => {
+    globalThis.document.documentElement.lang = locale;
   }, [locale]);
 
   return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;

--- a/src/renderer/src/i18n/pt-BR.ts
+++ b/src/renderer/src/i18n/pt-BR.ts
@@ -57,6 +57,10 @@ export const ptBR: TranslationKeys = {
   'titlebar.settings': 'Configurações',
   'titlebar.keyboardShortcuts': 'Atalhos de teclado',
   'titlebar.close': 'Fechar',
+
+  // Landmark regions
+  'region.editor': 'Editor',
+  'region.preview': 'Pré-visualização',
   'titlebar.removeRecent': 'Remover {name} dos arquivos recentes',
   'titlebar.minimize': 'Minimizar',
   'titlebar.maximize': 'Maximizar',

--- a/src/renderer/src/i18n/types.ts
+++ b/src/renderer/src/i18n/types.ts
@@ -49,6 +49,10 @@ export type TranslationKeys = {
   'titlebar.settings': string;
   'titlebar.keyboardShortcuts': string;
   'titlebar.close': string;
+
+  // ── Landmark regions ─────────────────────────────────────────────
+  'region.editor': string;
+  'region.preview': string;
   'titlebar.minimize': string;
   'titlebar.maximize': string;
   'titlebar.restore': string;

--- a/tests/e2e/accessibility.test.ts
+++ b/tests/e2e/accessibility.test.ts
@@ -1,0 +1,182 @@
+import type { Page } from '@playwright/test';
+import { test, expect } from './fixture';
+
+/** Accessible name of an element, resolved the way assistive tech would. */
+async function accessibleName(window: Page, selector: string) {
+  return window.evaluate((sel: string) => {
+    const element = document.querySelector(sel);
+    if (!element) return null;
+
+    const labelledBy = element.getAttribute('aria-labelledby');
+    if (labelledBy) {
+      return document.getElementById(labelledBy)?.textContent?.trim() ?? null;
+    }
+
+    const label = element.getAttribute('aria-label');
+    if (label) return label;
+
+    const id = element.getAttribute('id');
+    if (id) {
+      const bound = document.querySelector(`label[for="${id}"]`);
+      if (bound) return bound.textContent?.trim() ?? null;
+    }
+
+    return null;
+  }, selector);
+}
+
+test.describe('accessibility', () => {
+  test('editor and preview are named landmarks', async ({ window }) => {
+    expect(await accessibleName(window, '.app-editor-pane')).toBe('Editor');
+    expect(await accessibleName(window, '.app-preview-pane')).toBe('Preview');
+  });
+
+  test('document language tracks the active locale', async ({ window }) => {
+    await expect
+      .poll(() => window.evaluate(() => document.documentElement.lang))
+      .toBe('en');
+
+    // Asserting 'en' alone proves nothing: index.html already ships lang="en".
+    // The regression is the attribute never changing, so switch and re-check.
+    await window.evaluate(async () => {
+      const settings = await window.marky.getSettings();
+      await window.marky.setSettings({ ...settings, language: 'pt-BR' });
+    });
+
+    // setSettings persists over IPC; the running renderer only picks the new
+    // locale up on bootstrap, which is why the fixture reloads too.
+    await window.reload();
+    await window.waitForLoadState('domcontentloaded');
+    await window.locator('header').waitFor({ state: 'visible' });
+
+    await expect
+      .poll(() => window.evaluate(() => document.documentElement.lang))
+      .toBe('pt-BR');
+  });
+
+  test('status notices live in an announced region', async ({ window }) => {
+    const region = window.locator('footer [role="status"]');
+    await expect(region).toHaveCount(1);
+    await expect(region).toHaveAttribute('aria-live', 'polite');
+  });
+
+  test('dialog exposes modal semantics and a name', async ({ window }) => {
+    await window.locator('button[aria-label="Settings"]').click();
+
+    const dialog = window.locator('[role="dialog"]');
+    await expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(await accessibleName(window, '[role="dialog"]')).toBe('Settings');
+
+    await window.keyboard.press('Escape');
+  });
+
+  test('every settings control has an accessible name', async ({ window }) => {
+    await window.locator('button[aria-label="Settings"]').click();
+
+    const unnamed = await window.evaluate(() => {
+      const panel = document.querySelector('[role="dialog"]');
+      if (!panel) return ['no dialog'];
+
+      return Array.from(
+        panel.querySelectorAll('select, input, textarea'),
+      ).flatMap((control) => {
+        const id = control.getAttribute('id');
+        const named =
+          control.getAttribute('aria-label') ||
+          control.getAttribute('aria-labelledby') ||
+          (id && document.querySelector(`label[for="${id}"]`));
+
+        return named ? [] : [control.tagName + (id ? `#${id}` : ' (no id)')];
+      });
+    });
+
+    expect(unnamed).toEqual([]);
+    await window.keyboard.press('Escape');
+  });
+
+  test('control groups carry their label', async ({ window }) => {
+    await window.locator('button[aria-label="Settings"]').click();
+
+    const groups = await window.evaluate(() =>
+      Array.from(document.querySelectorAll('[role="group"]')).map((group) => {
+        const id = group.getAttribute('aria-labelledby');
+        return id
+          ? (document.getElementById(id)?.textContent?.trim() ?? null)
+          : null;
+      }),
+    );
+
+    expect(groups).not.toContain(null);
+    expect(groups).toContain('Theme');
+    expect(groups).toContain('Color theme');
+
+    await window.keyboard.press('Escape');
+  });
+
+  test('theme buttons expose pressed state', async ({ window }) => {
+    await window.locator('button[aria-label="Settings"]').click();
+
+    // Scoped to the light/dark group specifically. The colour theme buttons
+    // already set aria-pressed, so an unscoped query passes either way.
+    const themeGroup = window.locator(
+      '[role="group"][aria-labelledby="settings-theme-label"]',
+    );
+    await expect(themeGroup.locator('button')).toHaveCount(2);
+    await expect(
+      themeGroup.locator('button[aria-pressed="true"]'),
+    ).toHaveCount(1);
+
+    await window.keyboard.press('Escape');
+  });
+
+  test('tab stays inside an open dialog', async ({ window }) => {
+    await window.locator('button[aria-label="Settings"]').click();
+
+    for (let i = 0; i < 40; i++) {
+      await window.keyboard.press('Tab');
+      const inside = await window.evaluate(() => {
+        const panel = document.querySelector('[role="dialog"]');
+        return panel ? panel.contains(document.activeElement) : false;
+      });
+      expect(inside).toBe(true);
+    }
+
+    await window.keyboard.press('Escape');
+  });
+
+  test('closing settings hands focus to the editor', async ({ window }) => {
+    await window.locator('button[aria-label="Settings"]').click();
+    await expect(window.locator('[role="dialog"]')).toBeVisible();
+
+    await window.keyboard.press('Escape');
+
+    // App deliberately focuses the editor when settings or help close, and its
+    // rAF runs after the modal's restore. What matters is that focus is never
+    // dropped on <body>, which is where it landed before.
+    await expect
+      .poll(() =>
+        window.evaluate(() => document.activeElement?.className ?? ''),
+      )
+      .toContain('cm-content');
+  });
+
+  test('cancelling the insert dialog restores the trigger', async ({
+    window,
+  }) => {
+    // No App-level focus handling for this one, so the modal's own restore is
+    // the only thing keeping focus off <body>.
+    await window.locator('button[aria-label="Split"]').click();
+    await window.locator('button[aria-label="Link"]').click();
+    await expect(window.locator('[role="dialog"]')).toBeVisible();
+
+    await window.keyboard.press('Escape');
+
+    await expect
+      .poll(() =>
+        window.evaluate(
+          () => document.activeElement?.getAttribute('aria-label') ?? null,
+        ),
+      )
+      .toBe('Link');
+  });
+});

--- a/tests/e2e/aria-snapshot.test.ts
+++ b/tests/e2e/aria-snapshot.test.ts
@@ -1,0 +1,94 @@
+import { test, expect } from './fixture';
+
+/**
+ * Assertions against the accessibility tree — what a screen reader consumes,
+ * rather than the attributes we happened to write. These catch what attribute
+ * checks cannot: reading order, nesting, and text announced twice.
+ *
+ * Note on toMatchAriaSnapshot: it matches the template as a *subset*, so it
+ * catches renamed and missing nodes but never extra ones. Duplicate labels are
+ * extra nodes, which is why the first test below walks the tree instead.
+ *
+ * A whole-dialog snapshot is deliberately avoided: the font pickers list
+ * locally installed families, so it would pass only on the machine that
+ * recorded it.
+ */
+test.describe('aria snapshots', () => {
+  test('no group label is announced twice', async ({ window }) => {
+    await window.locator('button[aria-label="Settings"]').click();
+
+    const snapshot = await window.locator('[role="dialog"]').ariaSnapshot();
+
+    // Every labelled group, by accessible name.
+    const groups = [...snapshot.matchAll(/- group "([^"]+)"/g)].map((m) => m[1]);
+    expect(groups.length).toBeGreaterThan(0);
+
+    // The same text must not also sit in the tree as loose static text: the
+    // group already carries it, so a screen reader would say it, then say it
+    // again on entering the group.
+    const duplicated = groups.filter((name) => {
+      const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      return new RegExp(`- (?:paragraph|text): ${escaped}\\s*$`, 'm').test(
+        snapshot,
+      );
+    });
+
+    expect(duplicated).toEqual([]);
+
+    await window.keyboard.press('Escape');
+  });
+
+  test('settings groups expose their controls', async ({ window }) => {
+    await window.locator('button[aria-label="Settings"]').click();
+
+    const themeGroup = window.getByRole('group', { name: 'Theme', exact: true });
+    await expect(themeGroup).toMatchAriaSnapshot(`
+      - group "Theme":
+        - button "Light"
+        - button "Dark"
+    `);
+
+    const colorGroup = window.getByRole('group', { name: 'Color theme' });
+    await expect(colorGroup).toMatchAriaSnapshot(`
+      - group "Color theme":
+        - button "Amethyst"
+        - button "Rose"
+        - button "Jade"
+        - button "Amber"
+        - button "Coral"
+        - button "Sapphire"
+    `);
+
+    await window.keyboard.press('Escape');
+  });
+
+  test('margin inputs are spinbuttons with names', async ({ window }) => {
+    await window.locator('button[aria-label="Settings"]').click();
+
+    const margins = window.getByRole('group', { name: 'PDF margins' });
+    await expect(margins).toMatchAriaSnapshot(`
+      - group "PDF margins (mm)":
+        - spinbutton "Top"
+        - spinbutton "Right"
+        - spinbutton "Bottom"
+        - spinbutton "Left"
+    `);
+
+    await window.keyboard.press('Escape');
+  });
+
+  test('help dialog exposes named sections', async ({ window }) => {
+    await window.locator('button[aria-label="Keyboard shortcuts"]').click();
+
+    // Table navigation only: the other sections print modifier keys, which
+    // differ between Windows and macOS.
+    await expect(window.locator('[role="dialog"]')).toMatchAriaSnapshot(`
+      - dialog "Keyboard Shortcuts":
+        - heading "Keyboard Shortcuts" [level=2]
+        - button "Close"
+        - heading "Table Navigation" [level=3]
+    `);
+
+    await window.keyboard.press('Escape');
+  });
+});


### PR DESCRIPTION
Closes #20.

Started with the label bindings in #20, then audited the rest of the app while I was in there and found four more gaps worth fixing in the same pass.

## #20 — settings labels

Labels were visual only: clicking one didn't focus its control, and screen readers announced the selects unnamed. The **font family select had no accessible name at all** — the size select beside it was the only one covered, via an `aria-label`.

Split into the two cases the issue called out. Single controls get `id` + `htmlFor` (from `useId`, since font fields render twice). Theme, colour theme, PDF margins and each font field are *sets* of controls that no single id can stand for, so they became labelled groups instead.

The light/dark buttons also conveyed selection through colour alone, while the colour theme buttons right below them already set `aria-pressed`. Brought them in line.

## The rest of the audit

Already fine: all 11 icon-only buttons have `aria-label`, landmarks exist, Escape closes dialogs, and lucide icons are `aria-hidden`.

Five gaps:

**Dialogs weren't dialogs.** The panel was a plain `div` — no `role`, no name, and `Tab` walked straight out into the app behind it. Now `role="dialog"` + `aria-modal`, named from the existing heading, with `Tab`/`Shift+Tab` wrapped inside the panel and focus returned to the opener on close.

**Status notices were never announced.** Save, export and open confirmations rendered as a visual pill that clears after 2.8s — screen reader users got no feedback the action happened. Now in an always-mounted `role="status"` region. Always-mounted matters: a live region added at the same moment as its content usually goes unannounced.

**`<html lang>` never changed.** `index.html` hardcodes `lang="en"` and nothing updated it, so pt-BR and es were announced with English pronunciation.

**Panes weren't landmarks.** A `<section>` with no accessible name isn't exposed as a region, so neither pane could be reached from a screen reader's region list.

**Group labels were announced twice.** This one came from the group work above, so it's self-inflicted. Pointing `aria-labelledby` at a still-visible label leaves the text in the tree *and* on the group:

```
- paragraph: Theme
- group "Theme":
    - button "Light" [pressed]

- group "Editor font":
    - paragraph: Editor font      <- inside the group it names
```

Five groups affected. Fixed by hiding the label from the tree — accessible name computation still reads elements referenced by `aria-labelledby`, and all five keep their names.

## Worth a reviewer's attention

**The modal captures its opener during render, not in an effect.** Effects run child-before-parent, and this component focuses its own scroll area, so any effect would capture something already inside the dialog. First draft had this bug and it silently made the restore a no-op.

**Closing settings focuses the editor, not the trigger.** `App.tsx:97` already does this on purpose — close settings, keep typing — and its `rAF` lands after the modal's restore. The first version of that test asserted the trigger and was simply wrong about the app. The modal's restore still earns its place: the insert dialog has no such override, and that's the case the test now covers.

**`toMatchAriaSnapshot` matches its template as a subset.** It catches renamed and missing nodes, never extra ones — so the first snapshot test passed against the duplicated labels. The duplicate check walks the tree and compares group names against loose text instead.

**No whole-dialog snapshot.** The font pickers list locally installed families, so a full snapshot would only ever pass on the machine that recorded it. Snapshots are scoped to stable subtrees, and the help dialog assertion uses Table Navigation because every other section prints modifier keys that differ on macOS.

## Checks

14 new e2e tests, each verified failing against `main` before being trusted. That check earned its keep — two early drafts passed unchanged and were testing nothing:

- one asserted `lang === "en"` when `index.html` already hardcoded it; now it switches locale and re-checks
- one matched any `aria-pressed` button when the colour theme buttons already had one; now scoped to the light/dark group

**86/86 e2e** (72 on `main`), 93 unit, typecheck/lint/build clean. New suite run three times for flake.

## Scope

These tests assert the accessibility tree a screen reader reads from. Nothing here drives a screen reader, so none of it proves what NVDA actually says. Follow-ups: #23 for axe-core scanning, #24 for announcement-level testing.

Unrelated, noticed while working: `theme-contrast.test.ts` fails on Windows checkouts. It matches CSS selectors with a literal `\n` while `index.css` has CRLF terminators, so `indexOf` misses and it throws "missing CSS block". Green on Linux CI, red locally. Not touched here.
