### PR TITLE
fix(ui): replace the platform select arrow with our own

### DIFF
--- a/src/renderer/src/components/ui/select.tsx
+++ b/src/renderer/src/components/ui/select.tsx
@@ -1,0 +1,38 @@
+import { ChevronDown } from 'lucide-react';
+import { inputClass } from '@renderer/components/ui/field';
+import { cn } from '@renderer/lib/utils';
+
+/**
+ * A native <select> with the platform's own arrow replaced.
+ *
+ * Windows draws an arrow that does not match anything else in the app, so
+ * `appearance-none` removes it and the chevron is drawn here instead. The
+ * element stays a real <select>, which keeps keyboard handling, type-ahead,
+ * label association and screen reader support that a div-based replacement
+ * would have to reimplement.
+ *
+ * The open dropdown list is still drawn by the operating system and cannot be
+ * styled from here. Only a custom listbox fixes that — see #17.
+ */
+export function Select({
+  className,
+  children,
+  ...props
+}: React.SelectHTMLAttributes<HTMLSelectElement>) {
+  return (
+    <div className="relative">
+      <select
+        className={cn(inputClass, 'appearance-none pr-9', className)}
+        {...props}
+      >
+        {children}
+      </select>
+      {/* Decorative: the select already announces itself, and clicks must fall
+          through to it rather than landing on the icon. */}
+      <ChevronDown
+        aria-hidden="true"
+        className="pointer-events-none absolute right-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+      />
+    </div>
+  );
+}

--- a/src/renderer/src/features/settings/components/settings-dialog.tsx
+++ b/src/renderer/src/features/settings/components/settings-dialog.tsx
@@ -8,6 +8,7 @@ import {
   inputClass,
 } from '@renderer/components/ui/field';
 import { Modal } from '@renderer/components/ui/modal';
+import { Select } from '@renderer/components/ui/select';
 import { cn } from '@renderer/lib/utils';
 import type { ExportFont, Locale, PdfPageSize } from '@shared/types';
 import {
@@ -126,13 +127,14 @@ function FontField({
       role="group"
       aria-labelledby={`${fieldId}-label`}
     >
-      <FieldLabel id={`${fieldId}-label`} aria-hidden>{label}</FieldLabel>
+      <FieldLabel id={`${fieldId}-label`} aria-hidden>
+        {label}
+      </FieldLabel>
       <div className="grid grid-cols-[minmax(0,1fr)_7.5rem] gap-2">
         <div className="min-w-0">
           <SubLabel htmlFor={familyId}>{familyLabel}</SubLabel>
-          <select
+          <Select
             id={familyId}
-            className={inputClass}
             value={value}
             onChange={(event) => onChange(event.target.value)}
           >
@@ -141,13 +143,12 @@ function FontField({
                 {option.label}
               </option>
             ))}
-          </select>
+          </Select>
         </div>
         <div>
           <SubLabel htmlFor={sizeId}>{sizeLabel}</SubLabel>
-          <select
+          <Select
             id={sizeId}
-            className={inputClass}
             aria-label={`${label} size`}
             value={fontSize}
             onChange={(event) => onFontSizeChange(Number(event.target.value))}
@@ -157,7 +158,7 @@ function FontField({
                 {option.label}
               </option>
             ))}
-          </select>
+          </Select>
         </div>
       </div>
       <FieldHint>{helper}</FieldHint>
@@ -258,9 +259,8 @@ export function SettingsDialog() {
           <FieldLabel htmlFor="settings-language">
             {t('settings.language')}
           </FieldLabel>
-          <select
+          <Select
             id="settings-language"
-            className={inputClass}
             value={settings.language}
             onChange={(event) =>
               updateSettings({ language: event.target.value as Locale })
@@ -271,7 +271,7 @@ export function SettingsDialog() {
                 {option.label}
               </option>
             ))}
-          </select>
+          </Select>
         </div>
 
         <div>
@@ -397,9 +397,8 @@ export function SettingsDialog() {
           <FieldLabel htmlFor="settings-export-font">
             {t('settings.documentFont')}
           </FieldLabel>
-          <select
+          <Select
             id="settings-export-font"
-            className={inputClass}
             value={settings.exportFont}
             onChange={(event) =>
               updateSettings({ exportFont: event.target.value as ExportFont })
@@ -410,16 +409,15 @@ export function SettingsDialog() {
                 {t(option.labelKey)}
               </option>
             ))}
-          </select>
+          </Select>
         </div>
 
         <div>
           <FieldLabel htmlFor="settings-pdf-page-size">
             {t('settings.pdfPageSize')}
           </FieldLabel>
-          <select
+          <Select
             id="settings-pdf-page-size"
-            className={inputClass}
             value={settings.pdfPageSize}
             onChange={(event) =>
               updateSettings({ pdfPageSize: event.target.value as PdfPageSize })
@@ -430,7 +428,7 @@ export function SettingsDialog() {
                 {option.label}
               </option>
             ))}
-          </select>
+          </Select>
         </div>
 
         <div>


### PR DESCRIPTION
Part of #17 — the closed state only. Deliberately does not close the issue.

## What this fixes

The first screenshot in #17: Windows draws a select arrow that matches nothing else in the app. `appearance: none` removes it and the chevron is drawn alongside instead, so the control looks like the rest of the dialog in both themes.

## Why it is still a native `<select>`

`<select>` is the one control that is accessible for free — keyboard handling, type-ahead, label association, screen reader support, on every platform. A div-based replacement has to reimplement all of it, and doing that badly would undo part of #22.

So the element stays native and only the chrome changes. The chevron is `aria-hidden` and ignores pointer events, so clicks over it fall through to the control.

Verified rather than assumed:

- clicking at the chevron's position hits `SELECT#settings-language`, not the icon
- focus lands on the real `<select>`
- `appearance` computes to `none`, so the platform arrow is gone
- keyboard selection changes the value
- all five selects keep their accessible name; `getByRole('combobox', { name })` resolves for each; zero unnamed selects in the dialog

The existing accessibility suite passes untouched, including the aria snapshot that expects `combobox` roles — which is the point of not replacing the element.

*(One false alarm along the way: an early probe reported the Language combobox as unnamed. The probe had switched the UI to Portuguese two lines earlier, so it was looking for "Language" while the label said "Idioma".)*

## What this does not fix

The second screenshot — the open dropdown list. That is drawn by the operating system and cannot be styled from the renderer at all. Only a custom listbox addresses it.

#17 also asks for search, which matters more than the styling: the preview font picker holds **192 options** on this machine and the editor picker 28, both pulled from local fonts. Scrolling 192 native rows is the actual usability problem.

That work is worth its own PR. Two things I would want to get right there, and neither is cosmetic:

- a real combobox contract — `aria-expanded`, `aria-controls`, `role="listbox"`/`option`, `aria-activedescendant`, plus arrows, Home/End, Enter, Escape, type-to-filter and scroll-into-view
- Escape currently closes the dialog, via the handler added in #22. With an open listbox it has to close the list first and stop there, or the whole dialog vanishes when someone dismisses a dropdown

Scope for that PR should be the two family pickers only. Language, font size, document font and page size hold 3–9 options each, gain nothing from search, and would inherit all the accessibility risk for free.

## Checks

121 unit, 86/86 e2e, typecheck/lint/build clean. Screenshots reviewed in both themes.
