### PR TITLE
test(e2e): sweep every surface with axe-core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "zustand": "^5.0.8"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.12.1",
         "@commitlint/cli": "^21.2.1",
         "@commitlint/config-conventional": "^21.2.0",
         "@eslint/js": "^9.39.0",
@@ -144,6 +145,19 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.12.1.tgz",
+      "integrity": "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.12.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -4723,6 +4737,16 @@
       "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/bail": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "zustand": "^5.0.8"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "@commitlint/cli": "^21.2.1",
     "@commitlint/config-conventional": "^21.2.0",
     "@eslint/js": "^9.39.0",

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -182,7 +182,7 @@ export function App() {
                 labelKey="region.preview"
                 ref={previewRef}
                 className="app-preview-pane focus:outline-none"
-                tabIndex={-1}
+                tabIndex={0}
               >
                 <div data-preview-root className="mx-auto max-w-3xl px-8 py-10">
                   <PreviewPane

--- a/src/renderer/src/features/editor/components/editor-pane.tsx
+++ b/src/renderer/src/features/editor/components/editor-pane.tsx
@@ -95,10 +95,13 @@ export function EditorPane({ value, onChange, onReady }: EditorPaneProps) {
       tableNavigationExtension,
       formattingKeymap,
       EditorView.lineWrapping,
+      // CodeMirror's editable surface reports as a textbox with no name of its
+      // own, so a screen reader announces the whole document unlabelled.
+      EditorView.contentAttributes.of({ 'aria-label': t('region.editor') }),
       theme,
       editorStateExtension(setFormatting, setStats),
     ],
-    [setFormatting, setStats],
+    [setFormatting, setStats, t],
   );
 
   const handleReady = useCallback(

--- a/src/renderer/src/features/titlebar/components/title-bar.tsx
+++ b/src/renderer/src/features/titlebar/components/title-bar.tsx
@@ -172,9 +172,11 @@ export function TitleBar({
     <div className="flex items-center gap-1" style={noDrag}>
       <Button
         variant="ghost"
+        size="icon"
         className="rounded-full"
         onClick={onNew}
         disabled={!canCreateNewDocument}
+        aria-label={t('titlebar.new')}
       >
         <FilePlus className="size-4" />
       </Button>

--- a/src/renderer/src/i18n/en.ts
+++ b/src/renderer/src/i18n/en.ts
@@ -44,6 +44,7 @@ export const en: TranslationKeys = {
   'settings.exportFontMono': 'Monospace',
 
   // Title bar
+  'titlebar.new': 'New document',
   'titlebar.open': 'Open',
   'titlebar.save': 'Save',
   'titlebar.saveCopy': 'Save a copy',

--- a/src/renderer/src/i18n/es.ts
+++ b/src/renderer/src/i18n/es.ts
@@ -44,6 +44,7 @@ export const es: TranslationKeys = {
   'settings.exportFontMono': 'Monoespaciada',
 
   // Barra de título
+  'titlebar.new': 'Nuevo documento',
   'titlebar.open': 'Abrir',
   'titlebar.save': 'Guardar',
   'titlebar.saveCopy': 'Guardar una copia',

--- a/src/renderer/src/i18n/pt-BR.ts
+++ b/src/renderer/src/i18n/pt-BR.ts
@@ -44,6 +44,7 @@ export const ptBR: TranslationKeys = {
   'settings.exportFontMono': 'Monoespaçada',
 
   // Barra de título
+  'titlebar.new': 'Novo documento',
   'titlebar.open': 'Abrir',
   'titlebar.save': 'Salvar',
   'titlebar.saveCopy': 'Salvar uma cópia',

--- a/src/renderer/src/i18n/types.ts
+++ b/src/renderer/src/i18n/types.ts
@@ -36,6 +36,7 @@ export type TranslationKeys = {
 
   // ── Title bar ────────────────────────────────────────────────────
   'titlebar.removeRecent': string;
+  'titlebar.new': string;
   'titlebar.open': string;
   'titlebar.save': string;
   'titlebar.saveCopy': string;

--- a/tests/e2e/axe.test.ts
+++ b/tests/e2e/axe.test.ts
@@ -1,0 +1,149 @@
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import type { Page } from '@playwright/test';
+import { test, expect } from './fixture';
+
+/**
+ * Rule-based accessibility scanning.
+ *
+ * The hand-written checks in accessibility.test.ts and aria-snapshot.test.ts
+ * only cover what someone thought to assert. This sweeps every surface with
+ * axe-core instead, which is how the unnamed New document button and the
+ * unnamed editor surface were found — both sat in files those tests already
+ * touched.
+ *
+ * axe-core is driven directly rather than through @axe-core/playwright: that
+ * wrapper opens a second page via Target.createTarget, which Electron does not
+ * support.
+ *
+ * Automated rules catch somewhere between a third and half of WCAG issues, so
+ * this complements the other two files rather than replacing them.
+ */
+const require = createRequire(import.meta.url);
+const AXE_SOURCE = readFileSync(require.resolve('axe-core/axe.min.js'), 'utf-8');
+
+const TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
+
+/**
+ * Rules accepted for now, with the reason. Anything serious or critical outside
+ * this set fails the run.
+ */
+const ACCEPTED: Record<string, string> = {
+  // --muted-foreground is 3.10:1 against --card in every dark palette and needs
+  // roughly +9.5 lightness to clear AA. That brightens every muted string in
+  // the app, so it is a palette decision rather than a test fix. Tracked with
+  // measurements in the follow-up issue.
+  'color-contrast': 'dark muted-foreground, tracked separately',
+  // CodeMirror's scroller is not focusable itself, but the contenteditable it
+  // wraps is, and moving the caret scrolls it. Keyboard users are not stranded.
+  'scrollable-region-focusable': 'cm-scroller scrolls via the caret',
+};
+
+/**
+ * Total accepted nodes across every surface and theme. A cap rather than an
+ * exact figure because it varies with how much text each surface renders, but
+ * low enough that a new batch of violations cannot hide inside it.
+ */
+const ACCEPTED_NODE_CAP = 40;
+
+type Violation = {
+  id: string;
+  impact: string | null;
+  help: string;
+  nodes: Array<{ target: string[]; failureSummary?: string }>;
+};
+
+async function scan(window: Page, label: string) {
+  await window.evaluate(AXE_SOURCE);
+  const result = (await window.evaluate(
+    (tags) =>
+      (window as unknown as { axe: { run: (c: unknown, o: unknown) => unknown } }).axe.run(
+        document,
+        { runOnly: { type: 'tag', values: tags } },
+      ),
+    TAGS,
+  )) as { violations: Violation[] };
+
+  const blocking = result.violations.filter(
+    (v) =>
+      (v.impact === 'critical' || v.impact === 'serious') && !ACCEPTED[v.id],
+  );
+
+  const accepted = result.violations
+    .filter((v) => ACCEPTED[v.id])
+    .reduce((total, v) => total + v.nodes.length, 0);
+
+  return {
+    label,
+    accepted,
+    blocking: blocking.map(
+      (v) =>
+        `${label}: ${v.impact} ${v.id} on ${v.nodes
+          .map((n) => n.target.join(' '))
+          .join(', ')} — ${v.help}`,
+    ),
+    // Not failed on, but surfaced so they do not go unnoticed.
+    advisory: result.violations
+      .filter((v) => v.impact !== 'critical' && v.impact !== 'serious')
+      .map((v) => `${label}: ${v.impact} ${v.id} (${v.nodes.length})`),
+  };
+}
+
+async function setTheme(window: Page, theme: string) {
+  await window.evaluate(async (value) => {
+    const settings = await window.marky.getSettings();
+    await window.marky.setSettings({ ...settings, theme: value });
+  }, theme);
+  await window.reload();
+  await window.waitForLoadState('domcontentloaded');
+  await window.locator('header').waitFor({ state: 'visible', timeout: 10_000 });
+}
+
+test.describe('axe accessibility scan', () => {
+  for (const theme of ['dark', 'light'] as const) {
+    test(`${theme} theme has no unaccepted violations`, async ({ window }) => {
+      test.setTimeout(180_000);
+      await setTheme(window, theme);
+
+      const results = [];
+
+      // Main window, one scan per view mode: each hides a different pane.
+      for (const [mode, label] of [
+        ['Split', 'split'],
+        ['Editor', 'editor'],
+        ['Preview', 'preview'],
+      ] as const) {
+        await window.locator(`button[aria-label="${mode}"]`).click();
+        await window.waitForTimeout(250);
+        results.push(await scan(window, `${theme}/${label}`));
+      }
+
+      await window.locator('button[aria-label="Split"]').click();
+
+      await window.locator('button[aria-label="Settings"]').click();
+      results.push(await scan(window, `${theme}/settings`));
+      await window.keyboard.press('Escape');
+
+      await window.locator('button[aria-label="Keyboard shortcuts"]').click();
+      results.push(await scan(window, `${theme}/help`));
+      await window.keyboard.press('Escape');
+
+      await window.locator('button[aria-label="Link"]').click();
+      results.push(await scan(window, `${theme}/insert-link`));
+      await window.keyboard.press('Escape');
+
+      await window.locator('button[aria-label="Image"]').click();
+      results.push(await scan(window, `${theme}/insert-image`));
+      await window.keyboard.press('Escape');
+
+      const advisory = results.flatMap((r) => r.advisory);
+      if (advisory.length) console.log('advisory:', advisory.join(' | '));
+
+      const acceptedTotal = results.reduce((sum, r) => sum + r.accepted, 0);
+      console.log(`${theme}: accepted nodes ${acceptedTotal}`);
+
+      expect(results.flatMap((r) => r.blocking)).toEqual([]);
+      expect(acceptedTotal).toBeLessThanOrEqual(ACCEPTED_NODE_CAP);
+    });
+  }
+});


### PR DESCRIPTION
Closes #23.

Adds rule-based accessibility scanning across every surface, and fixes the three real violations it found on the first run.

## One correction to #23

I claimed `@axe-core/playwright` "works on Electron unchanged". It does not — the wrapper calls `browserContext.newPage()`, and Electron answers `Protocol error (Target.createTarget): Not supported`. The tests drive `axe-core` directly instead, injecting it and calling `axe.run()` in the page. Same engine, no wrapper.

## What it found

All three were in files the hand-written accessibility tests already touched, which is the argument for having a scanner at all.

**The New document button had no accessible name.** `critical`. It is the only icon button in the title bar not using `size="icon"`, so my earlier audit — which grepped for that variant and reported 8/8 labelled — structurally could not have found it. Now labelled and sized to match its neighbours. There was no `titlebar.new` string at all, so that was added across all three locales.

**CodeMirror's editable surface had no accessible name.** `serious`. A screen reader announced the whole document as an unlabelled textbox. Fixed with `EditorView.contentAttributes`.

**The preview pane was `tabIndex={-1}`.** `serious`. That allowed programmatic focus on view change but left keyboard users unable to scroll it. Zero makes it a tab stop and keeps the programmatic focus working.

## What it accepts, and why

Two rules are accepted with reasons in the test, and accepted nodes are capped at 40 per theme — dark sits at 33, light at 6 — so a new batch cannot hide behind the existing ones.

`color-contrast` — `--muted-foreground` is 3.10:1 against `--card` in all six dark palettes and needs about +9.5 lightness. That brightens every muted string in the app, which is a palette decision, not a test fix. Measured and filed as #28, which also notes a second root cause: `theme-contrast.test.ts` only measures tokens against `--editor-surface`, so anything on the active line, a selection or a bracket highlight is checked against the wrong background.

`scrollable-region-focusable` — CodeMirror's scroller is not focusable itself, but the contenteditable it wraps is, and moving the caret scrolls it. Keyboard users are not stranded.

## Scope

Three view modes plus settings, help and both insert dialogs, in light and dark. Contrast rules are theme-dependent, so both themes matter.

Automated rules catch somewhere between a third and half of WCAG issues, so this complements `accessibility.test.ts` and `aria-snapshot.test.ts` rather than replacing them. Announcement-level testing is still open as #24.

## Checks

88/88 e2e (86 before), 121 unit, typecheck/lint/build clean. Verified the scan bites by removing the button label again — four surfaces reported it with selectors before the fix was restored.
