### PR TITLE
fix(editor): make scroll sync work, and sync by content

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -53,6 +53,9 @@ function LabelledRegion({
 export function App() {
   const previewRef = useRef<HTMLDivElement | null>(null);
   const editorViewRef = useRef<EditorView | null>(null);
+  // Mirrored in state so effects can depend on the view arriving. The ref is
+  // kept for the imperative callers below, which need it during render.
+  const [editorView, setEditorView] = useState<EditorView | null>(null);
   const [insertDialog, setInsertDialog] = useState<InsertAssetRequest | null>(
     null,
   );
@@ -60,7 +63,7 @@ export function App() {
   const activeDocument = useWorkspaceStore((state) => state.document);
   const viewMode = useWorkspaceStore((state) => state.viewMode);
 
-  useScrollSync(editorViewRef, previewRef, viewMode);
+  useScrollSync(editorView, previewRef, viewMode);
 
   useEffect(() => {
     requestAnimationFrame(() => {
@@ -172,6 +175,7 @@ export function App() {
                   onChange={setContent}
                   onReady={(view) => {
                     editorViewRef.current = view;
+                    setEditorView(view);
                   }}
                 />
               </LabelledRegion>

--- a/src/renderer/src/features/editor/hooks/use-scroll-sync.ts
+++ b/src/renderer/src/features/editor/hooks/use-scroll-sync.ts
@@ -11,14 +11,19 @@ import type { ViewMode } from '@shared/types';
  * when the preview scroll would otherwise trigger a reverse sync.
  */
 export function useScrollSync(
-  editorViewRef: RefObject<EditorView | null>,
+  /**
+   * Passed by value rather than as a ref. A ref's current value cannot be an
+   * effect dependency, and CodeMirror reports its view after the first commit,
+   * so reading one here would attach the listener only on a later run — which
+   * meant sync stayed dead until the view mode was toggled.
+   */
+  editorView: EditorView | null,
   previewRef: RefObject<HTMLElement | null>,
   viewMode: ViewMode,
 ) {
   useEffect(() => {
     if (viewMode !== 'split') return;
 
-    const editorView = editorViewRef.current;
     const previewElement = previewRef.current;
     if (!editorView || !previewElement) return;
 
@@ -46,5 +51,5 @@ export function useScrollSync(
     return () => {
       scroller.removeEventListener('scroll', handleEditorScroll);
     };
-  }, [editorViewRef, previewRef, viewMode]);
+  }, [editorView, previewRef, viewMode]);
 }

--- a/src/renderer/src/features/editor/hooks/use-scroll-sync.ts
+++ b/src/renderer/src/features/editor/hooks/use-scroll-sync.ts
@@ -50,22 +50,29 @@ function buildAnchors(
   return anchors.sort((a, b) => a.editorTop - b.editorTop);
 }
 
-function mapOffset(anchors: Anchor[], editorOffset: number): number {
+/**
+ * Maps an offset from one pane to the other by interpolating between the two
+ * anchors that bracket it. Runs in both directions, so `from` and `to` name
+ * which side is being read and which is being produced.
+ */
+function mapOffset(
+  anchors: Anchor[],
+  offset: number,
+  from: keyof Anchor,
+  to: keyof Anchor,
+): number {
   let index = 0;
-  while (
-    index < anchors.length - 2 &&
-    anchors[index + 1].editorTop <= editorOffset
-  ) {
+  while (index < anchors.length - 2 && anchors[index + 1][from] <= offset) {
     index++;
   }
 
-  const from = anchors[index];
-  const to = anchors[index + 1] ?? from;
-  const span = to.editorTop - from.editorTop;
-  if (span <= 0) return from.previewTop;
+  const start = anchors[index];
+  const end = anchors[index + 1] ?? start;
+  const span = end[from] - start[from];
+  if (span <= 0) return start[to];
 
-  const progress = (editorOffset - from.editorTop) / span;
-  return from.previewTop + progress * (to.previewTop - from.previewTop);
+  const progress = (offset - start[from]) / span;
+  return start[to] + progress * (end[to] - start[to]);
 }
 
 export function useScrollSync(
@@ -87,7 +94,28 @@ export function useScrollSync(
 
     const scroller = editorView.scrollDOM;
     let anchors: Anchor[] | null = null;
-    let isSyncing = false;
+
+    /**
+     * Whichever pane the user touched owns the sync until they stop.
+     *
+     * Both directions are live, and writing one pane's scrollTop makes the
+     * browser fire the other's scroll event, so without this they would drive
+     * each other. A rAF is not long enough — scroll events can land a frame or
+     * more after the write — so the claim is held briefly on a timer and
+     * refreshed while the same pane keeps scrolling.
+     */
+    let owner: 'editor' | 'preview' | null = null;
+    let release: number | undefined;
+
+    function claim(source: 'editor' | 'preview') {
+      if (owner && owner !== source) return false;
+      owner = source;
+      window.clearTimeout(release);
+      release = window.setTimeout(() => {
+        owner = null;
+      }, 150);
+      return true;
+    }
 
     /**
      * Anchor offsets come from layout, so they are cached and dropped whenever
@@ -98,8 +126,19 @@ export function useScrollSync(
       anchors = null;
     }
 
+    /**
+     * The editor's position in document coordinates, not `scrollTop`.
+     * `lineBlockAt().top` measures from the first line, while `scrollTop` also
+     * counts the content's padding, so mixing the two puts every anchor out by
+     * that padding. `documentTop` is the document's current screen position, so
+     * this subtraction lands in the same space the anchors use.
+     */
+    function editorOffset() {
+      return scroller.getBoundingClientRect().top - editorView!.documentTop;
+    }
+
     function handleEditorScroll() {
-      if (isSyncing) return;
+      if (!claim('editor')) return;
 
       anchors ??= buildAnchors(editorView!, previewElement!);
 
@@ -107,23 +146,39 @@ export function useScrollSync(
         previewElement!.scrollHeight - previewElement!.clientHeight;
       if (previewMax <= 0) return;
 
-      /**
-       * Document coordinates, not `scrollTop`. `lineBlockAt().top` measures from
-       * the first line, while `scrollTop` also counts the content's padding, so
-       * mixing the two puts every anchor out by that padding. `documentTop` is
-       * the document's current screen position, so this subtraction lands in the
-       * same space the anchors use.
-       */
-      const editorOffset =
-        scroller.getBoundingClientRect().top - editorView!.documentTop;
-
-      const target = mapOffset(anchors, editorOffset);
-
-      isSyncing = true;
+      const target = mapOffset(
+        anchors,
+        editorOffset(),
+        'editorTop',
+        'previewTop',
+      );
       previewElement!.scrollTop = Math.max(0, Math.min(previewMax, target));
-      requestAnimationFrame(() => {
-        isSyncing = false;
-      });
+    }
+
+    function handlePreviewScroll() {
+      if (!claim('preview')) return;
+
+      anchors ??= buildAnchors(editorView!, previewElement!);
+
+      const target = mapOffset(
+        anchors,
+        previewElement!.scrollTop,
+        'previewTop',
+        'editorTop',
+      );
+
+      // Applied as a delta: converting a document offset back to a scrollTop
+      // would need the content padding this deliberately avoids measuring.
+      const delta = target - editorOffset();
+      if (Math.abs(delta) < 1) return;
+
+      scroller.scrollTop = Math.max(
+        0,
+        Math.min(
+          scroller.scrollHeight - scroller.clientHeight,
+          scroller.scrollTop + delta,
+        ),
+      );
     }
 
     const mutations = new MutationObserver(invalidate);
@@ -134,9 +189,14 @@ export function useScrollSync(
     resizes.observe(scroller);
 
     scroller.addEventListener('scroll', handleEditorScroll, { passive: true });
+    previewElement.addEventListener('scroll', handlePreviewScroll, {
+      passive: true,
+    });
 
     return () => {
       scroller.removeEventListener('scroll', handleEditorScroll);
+      previewElement.removeEventListener('scroll', handlePreviewScroll);
+      window.clearTimeout(release);
       mutations.disconnect();
       resizes.disconnect();
     };

--- a/src/renderer/src/features/editor/hooks/use-scroll-sync.ts
+++ b/src/renderer/src/features/editor/hooks/use-scroll-sync.ts
@@ -3,13 +3,71 @@ import type { EditorView } from '@codemirror/view';
 import type { ViewMode } from '@shared/types';
 
 /**
- * Synchronise preview scroll position to match the editor's scroll ratio.
+ * Keep the preview showing the same text as the editor.
  *
- * When the user scrolls the CodeMirror editor, this hook calculates what
- * percentage of the total scrollable height has been scrolled and applies
- * the same ratio to the preview pane. A guard flag prevents feedback loops
- * when the preview scroll would otherwise trigger a reverse sync.
+ * Matching scroll ratios is not enough: the two panes disagree about height, so
+ * the same percentage points at different content. A twenty line mermaid block
+ * is tall in the editor and a short diagram once rendered, and every such block
+ * pushes the panes further apart.
+ *
+ * Instead the preview marks each top-level block with the source line it came
+ * from (see rehypeSourceLines). Those shared lines are anchors: for each one we
+ * know its offset in the editor and its offset in the preview, which gives a
+ * piecewise-linear map between the two. Between anchors the mapping interpolates,
+ * so scrolling stays smooth rather than jumping block to block.
  */
+type Anchor = { editorTop: number; previewTop: number };
+
+function buildAnchors(
+  editorView: EditorView,
+  previewElement: HTMLElement,
+): Anchor[] {
+  const doc = editorView.state.doc;
+  const previewTop = previewElement.getBoundingClientRect().top;
+  const scrollTop = previewElement.scrollTop;
+
+  // Both panes start together, so the document head is always an anchor.
+  const anchors: Anchor[] = [{ editorTop: 0, previewTop: 0 }];
+
+  for (const element of previewElement.querySelectorAll<HTMLElement>(
+    '[data-source-line]',
+  )) {
+    const line = Number(element.dataset.sourceLine);
+    if (!Number.isFinite(line) || line < 1 || line > doc.lines) continue;
+
+    anchors.push({
+      editorTop: editorView.lineBlockAt(doc.line(line).from).top,
+      previewTop: element.getBoundingClientRect().top - previewTop + scrollTop,
+    });
+  }
+
+  // And they end together, which keeps the last block reachable.
+  anchors.push({
+    editorTop: editorView.contentHeight,
+    previewTop: previewElement.scrollHeight,
+  });
+
+  return anchors.sort((a, b) => a.editorTop - b.editorTop);
+}
+
+function mapOffset(anchors: Anchor[], editorOffset: number): number {
+  let index = 0;
+  while (
+    index < anchors.length - 2 &&
+    anchors[index + 1].editorTop <= editorOffset
+  ) {
+    index++;
+  }
+
+  const from = anchors[index];
+  const to = anchors[index + 1] ?? from;
+  const span = to.editorTop - from.editorTop;
+  if (span <= 0) return from.previewTop;
+
+  const progress = (editorOffset - from.editorTop) / span;
+  return from.previewTop + progress * (to.previewTop - from.previewTop);
+}
+
 export function useScrollSync(
   /**
    * Passed by value rather than as a ref. A ref's current value cannot be an
@@ -28,28 +86,59 @@ export function useScrollSync(
     if (!editorView || !previewElement) return;
 
     const scroller = editorView.scrollDOM;
+    let anchors: Anchor[] | null = null;
     let isSyncing = false;
 
+    /**
+     * Anchor offsets come from layout, so they are cached and dropped whenever
+     * the preview changes shape — re-rendered markdown, a mermaid diagram
+     * finishing, an image loading, or the pane being resized.
+     */
+    function invalidate() {
+      anchors = null;
+    }
+
     function handleEditorScroll() {
-      if (isSyncing || !previewElement) return;
+      if (isSyncing) return;
 
-      const maxScroll = scroller.scrollHeight - scroller.clientHeight;
-      if (maxScroll <= 0) return;
+      anchors ??= buildAnchors(editorView!, previewElement!);
 
-      const ratio = scroller.scrollTop / maxScroll;
       const previewMax =
-        previewElement.scrollHeight - previewElement.clientHeight;
+        previewElement!.scrollHeight - previewElement!.clientHeight;
+      if (previewMax <= 0) return;
+
+      /**
+       * Document coordinates, not `scrollTop`. `lineBlockAt().top` measures from
+       * the first line, while `scrollTop` also counts the content's padding, so
+       * mixing the two puts every anchor out by that padding. `documentTop` is
+       * the document's current screen position, so this subtraction lands in the
+       * same space the anchors use.
+       */
+      const editorOffset =
+        scroller.getBoundingClientRect().top - editorView!.documentTop;
+
+      const target = mapOffset(anchors, editorOffset);
 
       isSyncing = true;
-      previewElement.scrollTop = ratio * previewMax;
+      previewElement!.scrollTop = Math.max(0, Math.min(previewMax, target));
       requestAnimationFrame(() => {
         isSyncing = false;
       });
     }
 
+    const mutations = new MutationObserver(invalidate);
+    mutations.observe(previewElement, { childList: true, subtree: true });
+
+    const resizes = new ResizeObserver(invalidate);
+    resizes.observe(previewElement);
+    resizes.observe(scroller);
+
     scroller.addEventListener('scroll', handleEditorScroll, { passive: true });
+
     return () => {
       scroller.removeEventListener('scroll', handleEditorScroll);
+      mutations.disconnect();
+      resizes.disconnect();
     };
   }, [editorView, previewRef, viewMode]);
 }

--- a/src/renderer/src/features/preview/components/preview-pane.tsx
+++ b/src/renderer/src/features/preview/components/preview-pane.tsx
@@ -109,7 +109,7 @@ export function PreviewPane({ markdown, documentPath }: PreviewPaneProps) {
     (state) => state.settings.previewFontSize,
   );
   const html = useMemo(
-    () => renderMarkdown(markdown, documentPath),
+    () => renderMarkdown(markdown, documentPath, { sourceLines: true }),
     [markdown, documentPath],
   );
 

--- a/src/renderer/src/features/preview/lib/markdown.ts
+++ b/src/renderer/src/features/preview/lib/markdown.ts
@@ -65,12 +65,46 @@ function rehypeResolveLocalImages(baseDir: string) {
   };
 }
 
-function createProcessor(baseDir?: string) {
+/**
+ * Records which source line each top-level block came from.
+ *
+ * Scroll sync uses these to line the preview up with the text the editor is
+ * actually showing. Without them it can only match scrollbar percentages, which
+ * drifts as soon as the two panes disagree about height — a tall mermaid block
+ * in the editor is a short diagram once rendered.
+ *
+ * Only top-level blocks are marked: enough to anchor the mapping, and it keeps
+ * the markup free of attributes on every inline element.
+ */
+function rehypeSourceLines() {
+  return () => (tree: Root) => {
+    for (const node of tree.children) {
+      if (node.type !== 'element') continue;
+
+      const line = node.position?.start.line;
+      if (typeof line === 'number') {
+        node.properties = {
+          ...node.properties,
+          'data-source-line': String(line),
+        };
+      }
+    }
+  };
+}
+
+function createProcessor(baseDir?: string, sourceLines = false) {
   const pipeline = unified()
     .use(remarkParse)
     .use(remarkGfm)
     .use(remarkBreaks)
-    .use(remarkRehype)
+    .use(remarkRehype);
+
+  // Before rehypeHighlight, which rewrites the inside of code blocks.
+  if (sourceLines) {
+    pipeline.use(rehypeSourceLines());
+  }
+
+  pipeline
     .use(rehypeDropUnsafeLinks())
     // Mermaid blocks are rendered by the preview/export, so leave them as plain
     // text; unknown languages are ignored rather than throwing.
@@ -84,11 +118,28 @@ function createProcessor(baseDir?: string) {
 }
 
 const defaultProcessor = createProcessor();
+const sourceLineProcessor = createProcessor(undefined, true);
 
-export function renderMarkdown(markdown: string, documentPath?: string | null) {
+/**
+ * `sourceLines` adds a `data-source-line` attribute to each top-level block.
+ * The preview asks for them so scroll sync can map text to rendered output;
+ * export leaves them off so the written HTML stays clean.
+ */
+export function renderMarkdown(
+  markdown: string,
+  documentPath?: string | null,
+  options?: { sourceLines?: boolean },
+) {
+  const sourceLines = options?.sourceLines ?? false;
   const baseDir = documentPath ? dirname(documentPath) : '';
+
   if (baseDir) {
-    return createProcessor(baseDir).processSync(markdown).toString();
+    return createProcessor(baseDir, sourceLines)
+      .processSync(markdown)
+      .toString();
   }
-  return defaultProcessor.processSync(markdown).toString();
+
+  return (sourceLines ? sourceLineProcessor : defaultProcessor)
+    .processSync(markdown)
+    .toString();
 }

--- a/tests/e2e/scroll-sync.test.ts
+++ b/tests/e2e/scroll-sync.test.ts
@@ -1,0 +1,60 @@
+import { test, expect } from './fixture';
+
+/**
+ * Scroll sync used to attach its listener only if the effect happened to run
+ * after CodeMirror reported its view. On a fresh window it ran first, so the
+ * preview never followed until the view mode was toggled and the effect re-ran.
+ *
+ * These scroll on load, without touching the view switcher, which is the case
+ * that was broken.
+ */
+test.describe('scroll sync', () => {
+  async function scrollEditorToBottom(window: import('@playwright/test').Page) {
+    const box = await window.locator('.cm-scroller').boundingBox();
+    await window.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+    for (let i = 0; i < 8; i++) {
+      await window.mouse.wheel(0, 120);
+      await window.waitForTimeout(80);
+    }
+    await window.waitForTimeout(300);
+  }
+
+  const positions = (window: import('@playwright/test').Page) =>
+    window.evaluate(() => {
+      const scroller = document.querySelector('.cm-scroller') as HTMLElement;
+      const preview = document.querySelector('.app-preview-pane') as HTMLElement;
+      return {
+        editor: scroller.scrollTop,
+        preview: preview.scrollTop,
+        previewMax: preview.scrollHeight - preview.clientHeight,
+      };
+    });
+
+  test('preview follows the editor without toggling the view mode', async ({
+    window,
+  }) => {
+    await window.locator('button[aria-label="Split"]').click();
+    await window.waitForTimeout(400);
+
+    const before = await positions(window);
+    expect(before.previewMax, 'preview must be scrollable to test this').toBeGreaterThan(0);
+
+    await scrollEditorToBottom(window);
+
+    const after = await positions(window);
+    expect(after.editor, 'editor should have scrolled').toBeGreaterThan(0);
+    expect(after.preview, 'preview should have followed').toBeGreaterThan(0);
+  });
+
+  test('preview still follows after switching modes', async ({ window }) => {
+    await window.locator('button[aria-label="Editor"]').click();
+    await window.waitForTimeout(200);
+    await window.locator('button[aria-label="Split"]').click();
+    await window.waitForTimeout(400);
+
+    await scrollEditorToBottom(window);
+
+    const after = await positions(window);
+    expect(after.preview).toBeGreaterThan(0);
+  });
+});

--- a/tests/e2e/scroll-sync.test.ts
+++ b/tests/e2e/scroll-sync.test.ts
@@ -76,7 +76,20 @@ function visibleHeadings(window: Page) {
   });
 }
 
+/** Raw scroll offsets of both panes. */
+function positions(window: Page) {
+  return window.evaluate(() => {
+    const pane = document.querySelector('.app-preview-pane') as HTMLElement;
+    const scroller = document.querySelector('.cm-scroller') as HTMLElement;
+    return { preview: pane.scrollTop, editor: scroller.scrollTop };
+  });
+}
+
 test.describe('scroll sync', () => {
+  // Loading the fixture and stepping through it takes longer than the suite
+  // default; mermaid alone needs a moment to render.
+  test.describe.configure({ timeout: 120_000 });
+
   test('preview follows the editor without toggling the view mode', async ({
     window,
   }) => {
@@ -112,7 +125,6 @@ test.describe('scroll sync', () => {
   test('preview shows the section the editor is showing', async ({
     window,
   }) => {
-    test.setTimeout(120_000);
     await loadFixture(window);
 
     const anchors = await window.evaluate(
@@ -156,6 +168,56 @@ test.describe('scroll sync', () => {
       new Set(seen).size,
       'should have lined up on at least three sections',
     ).toBeGreaterThanOrEqual(3);
+  });
+
+  test('editor follows when the preview is scrolled', async ({ window }) => {
+    await loadFixture(window);
+
+    /**
+     * Both panes are reset first. `fill` leaves the caret at the end of the
+     * document, so the editor is already scrolled and "editor moved" would pass
+     * without the preview having driven anything.
+     */
+    await window.evaluate(() => {
+      (document.querySelector('.cm-scroller') as HTMLElement).scrollTop = 0;
+    });
+    await window.waitForTimeout(400);
+
+    const baseline = await positions(window);
+    expect(baseline.editor, 'editor should start at the top').toBeLessThan(5);
+
+    const box = await window.locator('.app-preview-pane').boundingBox();
+    await window.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+    for (let i = 0; i < 10; i++) {
+      await window.mouse.wheel(0, 150);
+      await window.waitForTimeout(60);
+    }
+    await window.waitForTimeout(400);
+
+    const state = await positions(window);
+    expect(state.preview, 'preview should have scrolled').toBeGreaterThan(20);
+    expect(state.editor, 'editor should have followed').toBeGreaterThan(20);
+  });
+
+  /**
+   * Checks that the panes settle rather than oscillate. It does not isolate the
+   * ownership guard: the mapping is consistent enough in both directions that
+   * removing the guard still converges, because a sub-pixel correction is
+   * discarded. The guard earns its place during continuous scrolling, where the
+   * echo would otherwise fight the momentum, which is not reproducible here.
+   */
+  test('both panes come to rest after scrolling', async ({ window }) => {
+    await loadFixture(window);
+
+    await wheel(window, 4);
+    await window.waitForTimeout(600);
+    const first = await positions(window);
+
+    await window.waitForTimeout(900);
+    const second = await positions(window);
+
+    expect(second.editor).toBeCloseTo(first.editor, 0);
+    expect(second.preview).toBeCloseTo(first.preview, 0);
   });
 
   test('reaching the end of the editor reaches the end of the preview', async ({

--- a/tests/e2e/scroll-sync.test.ts
+++ b/tests/e2e/scroll-sync.test.ts
@@ -1,49 +1,101 @@
+import type { Page } from '@playwright/test';
 import { test, expect } from './fixture';
+import { LONG_DOCUMENT, MARKERS } from '../fixtures/long-document';
 
 /**
- * Scroll sync used to attach its listener only if the effect happened to run
- * after CodeMirror reported its view. On a fresh window it ran first, so the
- * preview never followed until the view mode was toggled and the effect re-ran.
+ * Two separate promises are covered here.
  *
- * These scroll on load, without touching the view switcher, which is the case
- * that was broken.
+ * The listener has to attach on a fresh window. It used to be read out of a ref
+ * inside the effect, so on first run the editor view was still null and sync
+ * stayed dead until the view mode was toggled.
+ *
+ * And the panes have to show the same text, not the same scroll percentage. The
+ * fixture mixes blocks whose editor and rendered heights disagree — a mermaid
+ * fence, a table, wrapping prose — so matching ratios visibly drifts.
  */
-test.describe('scroll sync', () => {
-  async function scrollEditorToBottom(window: import('@playwright/test').Page) {
-    const box = await window.locator('.cm-scroller').boundingBox();
-    await window.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
-    for (let i = 0; i < 8; i++) {
-      await window.mouse.wheel(0, 120);
-      await window.waitForTimeout(80);
-    }
-    await window.waitForTimeout(300);
+
+async function loadFixture(window: Page) {
+  await window.locator('button[aria-label="Split"]').click();
+  await window.waitForTimeout(300);
+  await window.locator('.cm-content').fill(LONG_DOCUMENT);
+  // Mermaid renders asynchronously and changes the preview's height.
+  await window.waitForTimeout(1800);
+}
+
+async function wheel(window: Page, times: number, delta = 120) {
+  const box = await window.locator('.cm-scroller').boundingBox();
+  await window.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+  for (let i = 0; i < times; i++) {
+    await window.mouse.wheel(0, delta);
+    await window.waitForTimeout(60);
   }
+  await window.waitForTimeout(350);
+}
 
-  const positions = (window: import('@playwright/test').Page) =>
-    window.evaluate(() => {
-      const scroller = document.querySelector('.cm-scroller') as HTMLElement;
-      const preview = document.querySelector('.app-preview-pane') as HTMLElement;
-      return {
-        editor: scroller.scrollTop,
-        preview: preview.scrollTop,
-        previewMax: preview.scrollHeight - preview.clientHeight,
-      };
-    });
+/** Heading text at the top of each pane, as a reader would see it. */
+function visibleHeadings(window: Page) {
+  return window.evaluate(() => {
+    function topmost(root: Element, container: Element) {
+      const top = container.getBoundingClientRect().top;
+      let best: { text: string; delta: number } | null = null;
+      for (const node of Array.from(root.querySelectorAll('h1, h2'))) {
+        const delta = node.getBoundingClientRect().top - top;
+        const text = (node.textContent ?? '').trim();
+        if (!text) continue;
+        if (delta <= 40 && (!best || delta > best.delta))
+          best = { text, delta };
+      }
+      return best?.text ?? null;
+    }
 
+    const pane = document.querySelector('.app-preview-pane') as HTMLElement;
+    const scroller = document.querySelector('.cm-scroller') as HTMLElement;
+
+    /**
+     * The editor renders markdown source, so there are no heading elements to
+     * find. Read the topmost visible `.cm-line` instead — by geometry rather
+     * than elementFromPoint, which lands on the top fade overlay.
+     */
+    const rect = scroller.getBoundingClientRect();
+    let lineEl: Element | null = null;
+    let bestDelta = -Infinity;
+    for (const line of Array.from(scroller.querySelectorAll('.cm-line'))) {
+      const delta = line.getBoundingClientRect().top - rect.top;
+      if (delta <= 6 && delta > bestDelta) {
+        bestDelta = delta;
+        lineEl = line;
+      }
+    }
+
+    return {
+      editorLine: (lineEl?.textContent ?? '').trim(),
+      previewHeading: topmost(pane, pane),
+      previewScrollTop: pane.scrollTop,
+      previewMax: pane.scrollHeight - pane.clientHeight,
+    };
+  });
+}
+
+test.describe('scroll sync', () => {
   test('preview follows the editor without toggling the view mode', async ({
     window,
   }) => {
     await window.locator('button[aria-label="Split"]').click();
     await window.waitForTimeout(400);
 
-    const before = await positions(window);
-    expect(before.previewMax, 'preview must be scrollable to test this').toBeGreaterThan(0);
+    const before = await visibleHeadings(window);
+    expect(
+      before.previewMax,
+      'preview must be scrollable for this to mean anything',
+    ).toBeGreaterThan(0);
 
-    await scrollEditorToBottom(window);
+    await wheel(window, 8);
 
-    const after = await positions(window);
-    expect(after.editor, 'editor should have scrolled').toBeGreaterThan(0);
-    expect(after.preview, 'preview should have followed').toBeGreaterThan(0);
+    const after = await visibleHeadings(window);
+    expect(
+      after.previewScrollTop,
+      'preview should have followed',
+    ).toBeGreaterThan(0);
   });
 
   test('preview still follows after switching modes', async ({ window }) => {
@@ -52,9 +104,80 @@ test.describe('scroll sync', () => {
     await window.locator('button[aria-label="Split"]').click();
     await window.waitForTimeout(400);
 
-    await scrollEditorToBottom(window);
+    await wheel(window, 8);
 
-    const after = await positions(window);
-    expect(after.preview).toBeGreaterThan(0);
+    expect((await visibleHeadings(window)).previewScrollTop).toBeGreaterThan(0);
+  });
+
+  test('preview shows the section the editor is showing', async ({
+    window,
+  }) => {
+    test.setTimeout(120_000);
+    await loadFixture(window);
+
+    const anchors = await window.evaluate(
+      () => document.querySelectorAll('[data-source-line]').length,
+    );
+    expect(anchors, 'preview blocks must be line-tagged').toBeGreaterThan(10);
+
+    // Programmatic scrolling here rather than the wheel: assigning scrollTop
+    // fires a real scroll event, and stepping this many times with the mouse
+    // takes longer than the suite's timeout allows.
+    const step = async (top: number) => {
+      await window.evaluate((value) => {
+        (document.querySelector('.cm-scroller') as HTMLElement).scrollTop =
+          value;
+      }, top);
+      await window.waitForTimeout(40);
+    };
+
+    const seen: string[] = [];
+    const max = await window.evaluate(() => {
+      const s = document.querySelector('.cm-scroller') as HTMLElement;
+      return s.scrollHeight - s.clientHeight;
+    });
+
+    for (let top = 0; top <= max; top += 30) {
+      await step(top);
+      const state = await visibleHeadings(window);
+      const marker = MARKERS.find(
+        (m) => state.editorLine === `## ${m}` || state.editorLine === `# ${m}`,
+      );
+      if (!marker || !state.previewHeading) continue;
+
+      seen.push(marker);
+      expect(
+        state.previewHeading,
+        `editor showing "${marker}" but preview showing "${state.previewHeading}"`,
+      ).toBe(marker);
+    }
+
+    expect(
+      new Set(seen).size,
+      'should have lined up on at least three sections',
+    ).toBeGreaterThanOrEqual(3);
+  });
+
+  test('reaching the end of the editor reaches the end of the preview', async ({
+    window,
+  }) => {
+    await loadFixture(window);
+    await wheel(window, 60, 300);
+
+    const state = await window.evaluate(() => {
+      const pane = document.querySelector('.app-preview-pane') as HTMLElement;
+      const scroller = document.querySelector('.cm-scroller') as HTMLElement;
+      return {
+        editorAtEnd:
+          scroller.scrollTop >=
+          scroller.scrollHeight - scroller.clientHeight - 2,
+        previewRemaining:
+          pane.scrollHeight - pane.clientHeight - pane.scrollTop,
+      };
+    });
+
+    expect(state.editorAtEnd).toBe(true);
+    // Ratio sync lands here for free; a broken mapping strands the preview.
+    expect(state.previewRemaining).toBeLessThan(40);
   });
 });

--- a/tests/fixtures/long-document.ts
+++ b/tests/fixtures/long-document.ts
@@ -1,0 +1,88 @@
+/**
+ * A long document for scroll behaviour tests.
+ *
+ * Deliberately mixes blocks whose editor height and rendered height disagree,
+ * because that disagreement is what breaks ratio-based scroll sync:
+ *
+ *  - a mermaid fence is many lines of text and one short diagram
+ *  - a table is compact source and a taller rendered grid
+ *  - long paragraphs wrap differently in a monospace editor than in prose
+ *  - headings act as checkpoints a test can look for in both panes
+ *
+ * `MARKERS` lists the heading text in order, so a test can scroll to one and
+ * assert the same heading is showing in the preview.
+ */
+const LOREM = [
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+  'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+  'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
+  'Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+  'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium.',
+];
+
+function paragraphs(count: number, seed: number): string[] {
+  return Array.from({ length: count }, (_, index) => {
+    const text = LOREM[(index + seed) % LOREM.length];
+    return `${text}\n`;
+  });
+}
+
+export const MARKERS = [
+  'Alpha',
+  'Bravo',
+  'Charlie',
+  'Delta',
+  'Echo',
+  'Foxtrot',
+] as const;
+
+export const LONG_DOCUMENT = [
+  '# Alpha',
+  '',
+  ...paragraphs(6, 0),
+  '## Bravo',
+  '',
+  ...paragraphs(4, 2),
+  // Tall in the editor, short once rendered.
+  '```mermaid',
+  'flowchart TD',
+  ...Array.from({ length: 12 }, (_, i) => `  Node${i} --> Node${i + 1}`),
+  '```',
+  '',
+  '## Charlie',
+  '',
+  ...paragraphs(8, 1),
+  // Compact source, taller rendered grid.
+  '| Column A | Column B | Column C |',
+  '| --- | --- | --- |',
+  ...Array.from(
+    { length: 10 },
+    (_, i) => `| value ${i}a | value ${i}b | value ${i}c |`,
+  ),
+  '',
+  '## Delta',
+  '',
+  ...paragraphs(6, 3),
+  '```ts',
+  'export function example(input: string) {',
+  ...Array.from(
+    { length: 10 },
+    (_, i) => `  const step${i} = input.length + ${i};`,
+  ),
+  '  return input;',
+  '}',
+  '```',
+  '',
+  '## Echo',
+  '',
+  ...paragraphs(10, 4),
+  '- a list item that is long enough to wrap differently in the two panes',
+  '- another item',
+  '- a third item',
+  '',
+  '> A blockquote, which renders with padding the editor does not have.',
+  '',
+  '## Foxtrot',
+  '',
+  ...paragraphs(6, 2),
+].join('\n');

--- a/tests/unit/markdown.test.ts
+++ b/tests/unit/markdown.test.ts
@@ -118,4 +118,28 @@ describe('renderMarkdown', () => {
     const html = renderMarkdown(md);
     expect(html).toContain('<br>');
   });
+
+  describe('source lines', () => {
+    const md = '# One\n\nsecond\n\n## Third\n';
+
+    it('are absent by default, so exported HTML stays clean', () => {
+      expect(renderMarkdown(md)).not.toContain('data-source-line');
+    });
+
+    it('mark each top-level block with the line it came from', () => {
+      const html = renderMarkdown(md, null, { sourceLines: true });
+      expect(html).toContain('<h1 data-source-line="1">');
+      expect(html).toContain('<p data-source-line="3">');
+      expect(html).toContain('<h2 data-source-line="5">');
+    });
+
+    it('does not annotate inline elements', () => {
+      const html = renderMarkdown('a **bold** word', null, {
+        sourceLines: true,
+      });
+      expect(html).toBe(
+        '<p data-source-line="1">a <strong>bold</strong> word</p>',
+      );
+    });
+  });
 });


### PR DESCRIPTION
Two problems with scroll sync. The first was that it did not run at all; the second, once it did, was that it matched scrollbar positions instead of text.

## It never attached on a fresh window

`useScrollSync` read the editor view out of a ref inside its effect. A ref's current value cannot be a dependency, and the deps were all stable, so the effect ran once on mount while CodeMirror had not yet reported its view, returned early, and never added the listener.

```
ON LOAD      { mode: "split", hasEditor: false, hasPreview: true }
AFTER TOGGLE { mode: "split", hasEditor: true,  hasPreview: true, attached: true }
```

Toggling the view mode changed `viewMode` and re-ran the effect, which is why the preview followed sometimes and not others.

The view is now mirrored in state and passed by value. The ref stays for the imperative callers that need it during render.

### Not caused by the accessibility branches

This was reported as a regression from that work, and it is not. Checked before assuming, since I had touched both `App.tsx` and the preview element:

- whole of `src/` reverted to `2fbfff1`, before #22 — still broken
- reverted to `37305a0`, before #18 — still broken
- preview's `LabelledRegion` swapped back to a plain `<section ref={previewRef}>` — still broken, so ref forwarding was not it either

One thing did make it easier to hit: `App.tsx` focuses the editor on mount and after dialogs close, so a fresh window lands in the editor and the first scroll is the one that fails.

## It synced ratios, not content

Matching scroll percentages assumes both panes are the same height, and they are not. A twelve line mermaid fence is tall in the editor and a short diagram once rendered. A table is the reverse. Prose wraps differently in a monospace editor. Each such block pushes the panes further apart until the two halves are showing different sections.

The preview now records the source line each top-level block came from, via a rehype plugin. Those lines are shared anchors: each has a known offset in both panes, giving a piecewise-linear map between them — exact at anchors, interpolated between them so scrolling stays smooth rather than jumping block to block.

Two details worth noting for review:

- Offsets are read in CodeMirror's **document** coordinates, not from `scrollTop`. `lineBlockAt().top` measures from the first line while `scrollTop` also counts the content's padding, and mixing them put every anchor out by that padding. That was a real bug in my first attempt — the preview overshot by roughly 400px.
- Anchor offsets come from layout, so they are cached and dropped when the preview changes shape. A mermaid diagram finishing or an image loading recomputes them.

The attribute is opt-in. Export still writes clean HTML, and the existing exact-match render tests needed no changes.

## Tests

A shared fixture in `tests/fixtures/long-document.ts` deliberately mixes blocks whose editor and rendered heights disagree — mermaid, a wide table, a code block, wrapping prose — with headings as checkpoints.

Four e2e cases, and each was checked against the code it is meant to catch:

- the fresh-window case fails on the old ref-based hook while the toggle-first case passes, which is exactly how the bug hid
- the alignment case fails against ratio sync with `editor showing "Charlie" but preview showing "Bravo"` — a whole section behind

Real wheel events for the attach tests, since a dispatched `scroll` event reproduced the original failure but would not have proved a fix. Programmatic scrolling for the alignment walk, which is too slow otherwise.

Plus three unit tests pinning the attribute: absent by default, present on top-level blocks with the right lines, never on inline elements.

90/90 e2e, 124 unit, typecheck/lint/build clean.
