### PR TITLE
fix(theme): raise muted text contrast to WCAG AA

### DIFF
--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -168,7 +168,7 @@
     --secondary: 185 50% 92%;
     --secondary-foreground: 188 28% 28%;
     --muted: 184 42% 94%;
-    --muted-foreground: 186 14% 44%;
+    --muted-foreground: 186 14% 42%;
     --accent: 196 58% 90%;
     --accent-foreground: 190 31% 27%;
     --destructive: 353 70% 54%;
@@ -218,7 +218,7 @@
     --secondary: 75 50% 92%;
     --secondary-foreground: 78 28% 28%;
     --muted: 74 42% 94%;
-    --muted-foreground: 76 14% 44%;
+    --muted-foreground: 76 14% 40.5%;
     --accent: 86 58% 90%;
     --accent-foreground: 80 31% 27%;
     --destructive: 353 70% 54%;
@@ -268,7 +268,7 @@
     --secondary: 25 50% 92%;
     --secondary-foreground: 28 28% 28%;
     --muted: 24 42% 94%;
-    --muted-foreground: 26 14% 44%;
+    --muted-foreground: 26 14% 43.5%;
     --accent: 36 58% 90%;
     --accent-foreground: 30 31% 27%;
     --destructive: 353 70% 54%;
@@ -371,7 +371,7 @@
     --secondary: 245 14% 22%;
     --secondary-foreground: 60 20% 85%;
     --muted: 245 14% 20%;
-    --muted-foreground: 244 25% 55%;
+    --muted-foreground: 244 25% 64.5%;
     --accent: 245 14% 25%;
     --accent-foreground: 60 20% 88%;
     --destructive: 353 74% 61%;
@@ -421,7 +421,7 @@
     --secondary: 289 14% 22%;
     --secondary-foreground: 60 20% 85%;
     --muted: 289 14% 20%;
-    --muted-foreground: 288 25% 55%;
+    --muted-foreground: 288 25% 62.5%;
     --accent: 289 14% 25%;
     --accent-foreground: 60 20% 88%;
     --destructive: 353 74% 61%;
@@ -571,7 +571,7 @@
     --secondary: 355 14% 22%;
     --secondary-foreground: 60 20% 85%;
     --muted: 355 14% 20%;
-    --muted-foreground: 356 25% 55%;
+    --muted-foreground: 356 25% 63%;
     --accent: 355 14% 25%;
     --accent-foreground: 60 20% 88%;
     --destructive: 353 74% 61%;

--- a/tests/e2e/axe.test.ts
+++ b/tests/e2e/axe.test.ts
@@ -29,11 +29,12 @@ const TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
  * this set fails the run.
  */
 const ACCEPTED: Record<string, string> = {
-  // --muted-foreground is 3.10:1 against --card in every dark palette and needs
-  // roughly +9.5 lightness to clear AA. That brightens every muted string in
-  // the app, so it is a palette decision rather than a test fix. Tracked with
-  // measurements in the follow-up issue.
-  'color-contrast': 'dark muted-foreground, tracked separately',
+  // What remains is one token on the active line background: the heading colour
+  // is 4.06:1 against it in dark amethyst. The active line is a different root
+  // cause from the muted-foreground fix, and every token sits on it when the
+  // caret is there, so it needs the palette solved against that surface too.
+  // Measured and tracked separately.
+  'color-contrast': 'syntax tokens on the active line, tracked separately',
   // CodeMirror's scroller is not focusable itself, but the contenteditable it
   // wraps is, and moving the caret scrolls it. Keyboard users are not stranded.
   'scrollable-region-focusable': 'cm-scroller scrolls via the caret',
@@ -43,8 +44,11 @@ const ACCEPTED: Record<string, string> = {
  * Total accepted nodes across every surface and theme. A cap rather than an
  * exact figure because it varies with how much text each surface renders, but
  * low enough that a new batch of violations cannot hide inside it.
+ *
+ * Was 40 while dark sat at 33. Fixing muted-foreground dropped dark to 12 and
+ * light to 6, so the ceiling comes down with it.
  */
-const ACCEPTED_NODE_CAP = 40;
+const ACCEPTED_NODE_CAP = 15;
 
 type Violation = {
   id: string;

--- a/tests/unit/theme-contrast.test.ts
+++ b/tests/unit/theme-contrast.test.ts
@@ -105,6 +105,25 @@ describe('theme contrast (WCAG)', () => {
         expect(contrast(fg, bg)).toBeGreaterThanOrEqual(4.5);
       });
 
+      /**
+       * Muted text carries real content — section headings, hints, sub-labels,
+       * the unselected theme names — so AA applies to it as much as to body
+       * text. It was 3.10:1 against card in every dark palette until axe found
+       * it, which nothing here was checking.
+       *
+       * Only the surfaces it actually renders on. Any translucent panel is a
+       * blend of background and card, and clearing both brackets the blend.
+       */
+      it(`${mode}/${name}: muted text is legible on every surface it sits on`, () => {
+        const muted = hslTripletToRgb(vars['muted-foreground']);
+        for (const surface of ['background', 'card', 'editor-surface']) {
+          expect(
+            contrast(muted, hslTripletToRgb(vars[surface])),
+            `muted-foreground on ${surface} in ${mode}/${name}`,
+          ).toBeGreaterThanOrEqual(4.5);
+        }
+      });
+
       // 4.5:1 is WCAG AA for normal-size text, which is what code is. The
       // threshold used to be 3:1, under which every token passed while 18 sat
       // below the bar issue #4 actually asks for.


### PR DESCRIPTION
Closes #28.

Muted text carries real content — section headings, hints, sub-labels, the unselected theme names — and it was 3.10:1 against `--card` in dark amethyst. Nothing was checking it: `theme-contrast.test.ts` covered body text and syntax tokens, so axe was the first thing to notice.

## What changed

Six values, each moved by the smallest lightness step that clears 4.5:1 against every surface it renders on, with a little margin so browser rounding cannot push one back under.

| | from | to | shift |
|---|---|---|---|
| dark amethyst | `244 25% 55%` | `64.5%` | +9.5 |
| dark coral | `356 25% 55%` | `63%` | +8.0 |
| dark rose | `288 25% 55%` | `62.5%` | +7.5 |
| light amber | `76 14% 44%` | `40.5%` | −3.5 |
| light jade | `186 14% 44%` | `42%` | −2.0 |
| light coral | `26 14% 44%` | `43.5%` | −0.5 |

Dark jade, amber and sapphire already passed, as did light amethyst, rose and sapphire.

**Dark amethyst moves furthest, and it is the default theme.** Reviewed side by side: muted text reads clearly now and the app still reads calm — it has not become loud.

### Which surfaces count

Only `background`, `card` and `editor-surface`. Translucent panels are a blend of the first two, so clearing both brackets them — which is why the sample box axe flagged at 3.58:1 is covered without being measured directly.

`secondary` and `muted` also fail on paper, and I left them alone: neither is ever paired with muted text in the UI, so tuning against them would have brightened the app by another 2–3 points of lightness for nothing. Worth knowing if that pairing ever appears.

## Guard rails

`theme-contrast.test.ts` now asserts muted text against each surface it sits on, in both modes. Verified by reverting a value: it fails naming the pair and the ratio.

The axe ceiling drops from **40 accepted nodes to 15**. Dark went 33 → 12, light stayed at 6 — so the guard tightens instead of staying permanently loosened.

## What is left, and why it is not here

The remaining dark violation is one node of a different problem: the heading colour at 4.06:1 against the **active line** background. `theme-contrast.test.ts` measures tokens against `editor-surface`, but the caret's line has `editor-active-line` behind it, and every token sits there eventually.

Measured across all twelve palettes, that is roughly **35 token/background pairs** below AA — including `primary` at 2.03:1 in light amber, where headings are drawn in primary over a 7% tint of primary. That needs the solver from #25 re-run with the active line as a surface, plus a decision about the light tint, so it is filed as #31 with the full measurements rather than bolted on here.

## Checks

136 unit (124 before), 94/94 e2e, typecheck/lint/build clean. Before-and-after screenshots reviewed in both themes.
