### PR TITLE
fix(editor): give headings a colour meant for text

### DIFF
--- a/src/renderer/src/features/editor/lib/highlight-style.ts
+++ b/src/renderer/src/features/editor/lib/highlight-style.ts
@@ -3,6 +3,12 @@ import { tags as t } from '@lezer/highlight';
 
 const color = {
   foreground: 'hsl(var(--syntax-foreground))',
+  /**
+   * Headings and links used --primary directly, which is an accent built for
+   * fills and swatches rather than for text. On a light surface that reached
+   * 2.13:1 in amber. This keeps the accent's hue and darkens it enough to read.
+   */
+  heading: 'hsl(var(--syntax-heading))',
   comment: 'hsl(var(--syntax-comment))',
   string: 'hsl(var(--syntax-string))',
   keyword: 'hsl(var(--syntax-keyword))',
@@ -12,7 +18,6 @@ const color = {
   parameter: 'hsl(var(--syntax-parameter))',
   error: 'hsl(var(--syntax-error))',
   tag: 'hsl(var(--syntax-tag))',
-  accent: 'hsl(var(--primary))',
 } as const;
 
 /**
@@ -23,11 +28,11 @@ const color = {
  */
 export const markyHighlightStyle = HighlightStyle.define([
   // --- Markdown structural tokens ---
-  { tag: t.heading, color: color.accent, fontWeight: '700' },
+  { tag: t.heading, color: color.heading, fontWeight: '700' },
   { tag: t.strong, color: color.foreground, fontWeight: '700' },
   { tag: t.emphasis, color: color.foreground, fontStyle: 'italic' },
   { tag: t.strikethrough, textDecoration: 'line-through' },
-  { tag: [t.link, t.url], color: color.accent, textDecoration: 'underline' },
+  { tag: [t.link, t.url], color: color.heading, textDecoration: 'underline' },
   { tag: t.quote, color: color.comment, fontStyle: 'italic' },
   { tag: t.monospace, color: color.string },
   { tag: t.list, color: color.keyword },

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -89,6 +89,7 @@
     --editor-cursor: hsl(var(--primary));
     --editor-active-line: hsl(var(--primary) / 0.07);
     --editor-selection: hsl(var(--primary) / 0.22);
+    --syntax-heading: 269 52% 49%;
     --syntax-foreground: 268 24% 18%;
     --syntax-comment: 250 18% 46%;
     --syntax-string: 45 85% 29.5%;
@@ -139,6 +140,7 @@
     --editor-cursor: hsl(var(--primary));
     --editor-active-line: hsl(var(--primary) / 0.07);
     --editor-selection: hsl(var(--primary) / 0.22);
+    --syntax-heading: 349 52% 48.5%;
     --syntax-foreground: 268 24% 18%;
     --syntax-comment: 330 12% 46%;
     --syntax-string: 45 85% 29.5%;
@@ -189,6 +191,7 @@
     --editor-cursor: hsl(var(--primary));
     --editor-active-line: hsl(var(--primary) / 0.07);
     --editor-selection: hsl(var(--primary) / 0.22);
+    --syntax-heading: 189 52% 34.5%;
     --syntax-foreground: 268 24% 18%;
     --syntax-comment: 160 18% 40.5%;
     --syntax-string: 45 85% 29.5%;
@@ -239,6 +242,7 @@
     --editor-cursor: hsl(var(--primary));
     --editor-active-line: hsl(var(--primary) / 0.07);
     --editor-selection: hsl(var(--primary) / 0.22);
+    --syntax-heading: 79 52% 31.5%;
     --syntax-foreground: 268 24% 18%;
     --syntax-comment: 60 12% 32.5%;
     --syntax-string: 45 85% 29.5%;
@@ -289,6 +293,7 @@
     --editor-cursor: hsl(var(--primary));
     --editor-active-line: hsl(var(--primary) / 0.07);
     --editor-selection: hsl(var(--primary) / 0.22);
+    --syntax-heading: 29 52% 39%;
     --syntax-foreground: 268 24% 18%;
     --syntax-comment: 10 18% 46%;
     --syntax-string: 45 85% 29.5%;
@@ -339,6 +344,7 @@
     --editor-cursor: hsl(var(--primary));
     --editor-active-line: hsl(var(--primary) / 0.07);
     --editor-selection: hsl(var(--primary) / 0.22);
+    --syntax-heading: 229 52% 49%;
     --syntax-foreground: 268 24% 18%;
     --syntax-comment: 210 18% 45%;
     --syntax-string: 45 85% 29.5%;
@@ -392,6 +398,7 @@
     --editor-cursor: hsl(var(--primary));
     --editor-active-line: hsl(244 25% 25%);
     --editor-selection: hsl(245 15% 30%);
+    --syntax-heading: 250 100% 77.5%;
     --syntax-foreground: 60 30% 96%;
     --syntax-comment: 244 31% 63%;
     --syntax-string: 60 100% 75%;
@@ -442,6 +449,7 @@
     --editor-cursor: hsl(var(--primary));
     --editor-active-line: hsl(289 25% 25%);
     --editor-selection: hsl(290 15% 30%);
+    --syntax-heading: 330 100% 75%;
     --syntax-foreground: 60 30% 96%;
     --syntax-comment: 288 31% 59.5%;
     --syntax-string: 60 100% 75%;
@@ -492,6 +500,7 @@
     --editor-cursor: hsl(var(--primary));
     --editor-active-line: hsl(169 25% 25%);
     --editor-selection: hsl(170 15% 30%);
+    --syntax-heading: 170 100% 75%;
     --syntax-foreground: 60 30% 96%;
     --syntax-comment: 168 25% 55%;
     --syntax-string: 60 100% 75%;
@@ -542,6 +551,7 @@
     --editor-cursor: hsl(var(--primary));
     --editor-active-line: hsl(49 25% 25%);
     --editor-selection: hsl(50 15% 30%);
+    --syntax-heading: 60 100% 75%;
     --syntax-foreground: 60 30% 96%;
     --syntax-comment: 48 25% 55%;
     --syntax-string: 60 100% 75%;
@@ -592,6 +602,7 @@
     --editor-cursor: hsl(var(--primary));
     --editor-active-line: hsl(356 25% 25%);
     --editor-selection: hsl(355 15% 30%);
+    --syntax-heading: 10 100% 75%;
     --syntax-foreground: 60 30% 96%;
     --syntax-comment: 356 25% 59.5%;
     --syntax-string: 60 100% 75%;
@@ -642,6 +653,7 @@
     --editor-cursor: hsl(var(--primary));
     --editor-active-line: hsl(210 25% 25%);
     --editor-selection: hsl(209 15% 30%);
+    --syntax-heading: 210 100% 75%;
     --syntax-foreground: 60 30% 96%;
     --syntax-comment: 211 25% 55%;
     --syntax-string: 60 100% 75%;

--- a/tests/unit/theme-colorblind.test.ts
+++ b/tests/unit/theme-colorblind.test.ts
@@ -28,6 +28,7 @@ const css = readFileSync(
 
 const THEMES = ['amethyst', 'rose', 'jade', 'amber', 'coral', 'sapphire'];
 const SYNTAX_KEYS = [
+  'syntax-heading',
   'syntax-foreground',
   'syntax-comment',
   'syntax-string',
@@ -66,9 +67,11 @@ const KNOWN = new Set([
   'dark/amber deuteranopia function/parameter',
   'dark/amber protanopia comment/error',
   'dark/amber protanopia foreground/class',
+  'dark/amber protanopia heading/function',
   'dark/amber protanopia string/function',
   'dark/amber tritanopia error/tag',
   'dark/amber tritanopia foreground/string',
+  'dark/amber tritanopia heading/foreground',
   'dark/amber tritanopia keyword/error',
   'dark/amethyst deuteranopia function/parameter',
   'dark/amethyst protanopia foreground/class',
@@ -81,11 +84,14 @@ const KNOWN = new Set([
   'dark/coral protanopia string/function',
   'dark/coral tritanopia error/tag',
   'dark/coral tritanopia foreground/string',
+  'dark/coral tritanopia heading/keyword',
+  'dark/coral tritanopia heading/tag',
   'dark/coral tritanopia keyword/error',
   'dark/jade deuteranopia comment/keyword',
   'dark/jade deuteranopia comment/tag',
   'dark/jade deuteranopia function/parameter',
   'dark/jade protanopia foreground/class',
+  'dark/jade protanopia heading/foreground',
   'dark/jade protanopia string/function',
   'dark/jade tritanopia error/tag',
   'dark/jade tritanopia foreground/string',
@@ -95,6 +101,7 @@ const KNOWN = new Set([
   'dark/rose protanopia string/function',
   'dark/rose tritanopia error/tag',
   'dark/rose tritanopia foreground/string',
+  'dark/rose tritanopia heading/error',
   'dark/rose tritanopia keyword/error',
   'dark/sapphire deuteranopia function/parameter',
   'dark/sapphire protanopia comment/keyword',
@@ -104,9 +111,12 @@ const KNOWN = new Set([
   'dark/sapphire tritanopia error/tag',
   'dark/sapphire tritanopia foreground/string',
   'dark/sapphire tritanopia keyword/error',
+  'light/amber deuteranopia heading/error',
   'light/amber deuteranopia parameter/error',
   'light/amber deuteranopia string/error',
   'light/amber deuteranopia string/parameter',
+  'light/amber protanopia heading/parameter',
+  'light/amber protanopia heading/string',
   'light/amber protanopia string/parameter',
   'light/amber tritanopia function/class',
   'light/amethyst deuteranopia parameter/error',
@@ -119,6 +129,7 @@ const KNOWN = new Set([
   'light/coral deuteranopia parameter/error',
   'light/coral deuteranopia string/error',
   'light/coral deuteranopia string/parameter',
+  'light/coral protanopia heading/function',
   'light/coral protanopia string/parameter',
   'light/coral tritanopia comment/string',
   'light/coral tritanopia function/class',
@@ -129,14 +140,18 @@ const KNOWN = new Set([
   'light/jade deuteranopia string/parameter',
   'light/jade protanopia string/parameter',
   'light/jade tritanopia function/class',
+  'light/jade tritanopia heading/function',
   'light/rose deuteranopia comment/keyword',
   'light/rose deuteranopia comment/tag',
+  'light/rose deuteranopia heading/function',
   'light/rose deuteranopia parameter/error',
   'light/rose deuteranopia string/error',
   'light/rose deuteranopia string/parameter',
   'light/rose protanopia comment/class',
   'light/rose protanopia string/parameter',
   'light/rose tritanopia function/class',
+  'light/rose tritanopia heading/keyword',
+  'light/rose tritanopia heading/tag',
   'light/sapphire deuteranopia comment/class',
   'light/sapphire deuteranopia parameter/error',
   'light/sapphire deuteranopia string/error',
@@ -290,9 +305,14 @@ describe('syntax colours under colour vision deficiency', () => {
   // The count that actually matters. Everything else in KNOWN survives on
   // italics or a wavy underline; these are distinguishable by hue alone, so a
   // reader with colour vision deficiency has nothing else to go on.
-  it('adds no colour-only collapse beyond the recorded 42', () => {
+  //
+  // Went from 42 to 54 when headings became syntax-heading. Those collisions
+  // are not new: headings were drawn in --primary, which this file never
+  // measured, so naming the colour brought existing debt into view rather than
+  // adding any.
+  it('adds no colour-only collapse beyond the recorded 54', () => {
     const bare = collapsed.filter((pair) => !isMitigated(pair));
-    expect(bare.length).toBeLessThanOrEqual(42);
+    expect(bare.length).toBeLessThanOrEqual(54);
   });
 
   it('keeps error distinguishable by something other than hue', () => {

--- a/tests/unit/theme-contrast.test.ts
+++ b/tests/unit/theme-contrast.test.ts
@@ -19,6 +19,7 @@ const css = readFileSync(resolve('src/renderer/src/index.css'), 'utf-8').replace
 
 const THEMES = ['amethyst', 'rose', 'jade', 'amber', 'coral', 'sapphire'];
 const SYNTAX_KEYS = [
+  'syntax-heading',
   'syntax-foreground',
   'syntax-comment',
   'syntax-string',


### PR DESCRIPTION
Part of #31. Fixes the worse half of it; the active-line half is deliberately left open, reasoning below.

## What I found

Chasing the single active-line node from #31 turned up something larger and simpler. Headings and links in the editor were drawn in `--primary` — an accent built for fills, focus rings and the theme swatches. As text on a light editor surface it lands at:

| light theme | primary on editor surface |
|---|---|
| amber | **2.13:1** |
| jade | **2.48:1** |
| coral | **3.09:1** |

That is not about the active line. Headings were hard to read on the plain surface, in three of six light palettes, and it is obvious once you look at it — screenshot in the issue thread.

**Nothing was checking it.** `primary` was not in the syntax key list, so neither contrast suite measured it, and `axe.test.ts` only exercises the default amethyst palette, which passes at 6.08. Two layers of guard rail, both blind to the same colour.

## The fix

A `--syntax-heading` token, keeping the accent's hue and saturation and moving only lightness far enough to clear 4.5:1 against both the editor surface and the active line.

Seven of the twelve values are identical to `primary` because they already passed. `--primary` itself is untouched, so buttons, focus rings and the picker swatches look exactly as before — this separates "accent" from "accent used as text" rather than restyling the accent.

Both suites now measure `syntax-heading` like any other token.

### The colour-blindness count went up

Recorded colour-only collapses move from 42 to 54. Those collisions are not new: headings were already drawn in a colour neither suite measured, so naming it brought existing debt into view rather than creating it. Written into the test so the number is not mistaken for a regression later.

## What is not here

The original #31 scope — every token measured against the active line — needs a broader change than this. With the active line included as a surface, dark comments need **+13 lightness**, constants +9.5, keywords and tags +5.5, across all six dark palettes. That is a visible restyling of the editor rather than a correction, and it deserves its own look rather than riding along with a fix for an unreadable heading.

The measurements are already in #31. Worth pairing with #26 when it happens, since both want the contrast machinery extended and it would be better to tune the palette once against corrected numbers than twice.

## Checks

136 unit, 94/94 e2e, typecheck/lint/build clean. Light amber, light jade and dark amethyst reviewed by eye before and after.
