### PR TITLE
test(theme): measure colour vision deficiency with CIEDE2000

### DIFF
--- a/tests/unit/theme-colorblind.test.ts
+++ b/tests/unit/theme-colorblind.test.ts
@@ -8,18 +8,15 @@ import { describe, it, expect } from 'vitest';
  * clear 4.5:1 against the background and still be the same colour as each
  * other once simulated.
  *
- * Each palette is simulated for protanopia, deuteranopia and tritanopia, and
- * every token pair that is clearly distinct in normal vision is checked for
- * collapsing under simulation.
+ * Every palette is simulated across the protan, deutan and tritan families,
+ * and every token pair that is clearly distinct in normal vision is checked
+ * for collapsing under simulation.
  *
- * KNOWN is the debt that already exists, recorded so it cannot grow silently.
- * The suite fails both on a new collapse and on a stale entry, so the list has
- * to shrink deliberately rather than drift.
- *
- * Caveats worth remembering before treating this as a verdict: dE76 with a
- * threshold of 10 is a heuristic, CIEDE2000 would be more accurate, and the
- * matrices model full dichromacy while most colour vision deficiency is milder
- * anomalous trichromacy.
+ * KNOWN is the debt that already exists, grouped by conflict so the shape of
+ * it is visible: a conflict listing all twelve palettes is one shared colour
+ * pair to fix, a conflict listing one palette is local to that palette. The
+ * suite fails both on a new collapse and on a stale entry, so the list has to
+ * shrink deliberately rather than drift.
  */
 const css = readFileSync(
   resolve('src/renderer/src/index.css'),
@@ -41,125 +38,307 @@ const SYNTAX_KEYS = [
   'syntax-tag',
 ];
 
-/** Distinct in normal vision, and still distinct once simulated. */
+/**
+ * CIEDE2000 distance below which two colours read as the same colour.
+ *
+ * Anchored by rendering rather than assumed: token pairs were drawn as
+ * interleaved code in their simulated colours and inspected. Below about 9.7
+ * the two tokens in a line were not tellable apart; separation becomes
+ * reliable around 10 to 11. Side-by-side text in a single line is the easiest
+ * case there is — real code scatters these tokens — so the threshold sits at
+ * the optimistic end of what was legible, not beyond it.
+ *
+ * This replaced dE76 at the same numeric value, which is a coincidence and not
+ * a translation: the two metrics disagree sharply on saturated colours, and
+ * the swap roughly doubled the recorded debt because dE76 was calling pairs
+ * distinct that are not.
+ */
 const DISTINCT = 10;
 
-/** Machado, Oliveira & Fernandes (2009), severity 1.0, applied in linear RGB. */
-const DEFICIENCIES = {
-  protanopia: [
-    [0.152286, 1.052583, -0.204868],
-    [0.114503, 0.786281, 0.099216],
-    [-0.003882, -0.048116, 1.051998],
-  ],
-  deuteranopia: [
-    [0.367322, 0.860646, -0.227968],
-    [0.280085, 0.672501, 0.047413],
-    [-0.01182, 0.04294, 0.968881],
-  ],
-  tritanopia: [
-    [1.255528, -0.076749, -0.178779],
-    [-0.078411, 0.930809, 0.147602],
-    [0.004733, 0.691367, 0.3039],
-  ],
+/**
+ * Machado, Oliveira & Fernandes (2009), applied in linear RGB, as published in
+ * the colour-science dataset. Rows are the flattened 3x3 matrix.
+ *
+ * Severity 1.0 is dichromacy; lower severities are anomalous trichromacy,
+ * which is both milder and far more common. Severity 1.0 is not a worst case
+ * that subsumes the rest — `heading/comment` in dark amethyst collapses from
+ * 0.5 to 0.8 and separates again by 1.0 — so the whole range is swept.
+ */
+// prettier-ignore
+const CVD_MATRICES = {
+  protanomaly: {
+    0.5: [0.458064, 0.679578, -0.137642, 0.092785, 0.846313, 0.060902, -0.007494, -0.016807, 1.024301],
+    0.6: [0.385450, 0.769005, -0.154455, 0.100526, 0.829802, 0.069673, -0.007442, -0.022190, 1.029632],
+    0.7: [0.319627, 0.849633, -0.169261, 0.106241, 0.815969, 0.077790, -0.007025, -0.028051, 1.035076],
+    0.8: [0.259411, 0.923008, -0.182420, 0.110296, 0.804340, 0.085364, -0.006276, -0.034346, 1.040622],
+    0.9: [0.203876, 0.990338, -0.194214, 0.112975, 0.794542, 0.092483, -0.005222, -0.041043, 1.046265],
+    1.0: [0.152286, 1.052583, -0.204868, 0.114503, 0.786281, 0.099216, -0.003882, -0.048116, 1.051998],
+  },
+  deuteranomaly: {
+    0.5: [0.547494, 0.607765, -0.155259, 0.181692, 0.781742, 0.036566, -0.010410, 0.027275, 0.983136],
+    0.6: [0.498864, 0.674741, -0.173604, 0.205199, 0.754872, 0.039929, -0.011131, 0.030969, 0.980162],
+    0.7: [0.457771, 0.731899, -0.189670, 0.226409, 0.731012, 0.042579, -0.011595, 0.034333, 0.977261],
+    0.8: [0.422823, 0.781057, -0.203881, 0.245752, 0.709602, 0.044646, -0.011843, 0.037423, 0.974421],
+    0.9: [0.392952, 0.823610, -0.216562, 0.263559, 0.690210, 0.046232, -0.011910, 0.040281, 0.971630],
+    1.0: [0.367322, 0.860646, -0.227968, 0.280085, 0.672501, 0.047413, -0.011820, 0.042940, 0.968881],
+  },
+  tritanomaly: {
+    0.5: [1.017277, 0.027029, -0.044306, -0.006113, 0.958479, 0.047634, 0.006379, 0.248708, 0.744913],
+    0.6: [1.104996, -0.046633, -0.058363, -0.032137, 0.971635, 0.060503, 0.001336, 0.317922, 0.680742],
+    0.7: [1.193214, -0.109812, -0.083402, -0.058496, 0.979410, 0.079086, -0.002346, 0.403492, 0.598854],
+    0.8: [1.257728, -0.139648, -0.118081, -0.078003, 0.975409, 0.102594, -0.003316, 0.501214, 0.502102],
+    0.9: [1.278864, -0.125333, -0.153531, -0.084748, 0.957674, 0.127074, -0.000989, 0.601151, 0.399838],
+    1.0: [1.255528, -0.076749, -0.178779, -0.078411, 0.930809, 0.147602, 0.004733, 0.691367, 0.303900],
+  },
 } as const;
 
-const KNOWN = new Set([
-  'dark/amber deuteranopia function/parameter',
-  'dark/amber protanopia comment/error',
-  'dark/amber protanopia foreground/class',
-  'dark/amber protanopia heading/function',
-  'dark/amber protanopia string/function',
-  'dark/amber tritanopia error/tag',
-  'dark/amber tritanopia foreground/string',
-  'dark/amber tritanopia heading/foreground',
-  'dark/amber tritanopia keyword/error',
-  'dark/amethyst deuteranopia function/parameter',
-  'dark/amethyst protanopia foreground/class',
-  'dark/amethyst protanopia string/function',
-  'dark/amethyst tritanopia error/tag',
-  'dark/amethyst tritanopia foreground/string',
-  'dark/amethyst tritanopia keyword/error',
-  'dark/coral deuteranopia function/parameter',
-  'dark/coral protanopia foreground/class',
-  'dark/coral protanopia string/function',
-  'dark/coral tritanopia error/tag',
-  'dark/coral tritanopia foreground/string',
-  'dark/coral tritanopia heading/keyword',
-  'dark/coral tritanopia heading/tag',
-  'dark/coral tritanopia keyword/error',
-  'dark/jade deuteranopia comment/keyword',
-  'dark/jade deuteranopia comment/tag',
-  'dark/jade deuteranopia function/parameter',
-  'dark/jade protanopia foreground/class',
-  'dark/jade protanopia heading/foreground',
-  'dark/jade protanopia string/function',
-  'dark/jade tritanopia error/tag',
-  'dark/jade tritanopia foreground/string',
-  'dark/jade tritanopia keyword/error',
-  'dark/rose deuteranopia function/parameter',
-  'dark/rose protanopia foreground/class',
-  'dark/rose protanopia string/function',
-  'dark/rose tritanopia error/tag',
-  'dark/rose tritanopia foreground/string',
-  'dark/rose tritanopia heading/error',
-  'dark/rose tritanopia keyword/error',
-  'dark/sapphire deuteranopia function/parameter',
-  'dark/sapphire protanopia comment/keyword',
-  'dark/sapphire protanopia comment/tag',
-  'dark/sapphire protanopia foreground/class',
-  'dark/sapphire protanopia string/function',
-  'dark/sapphire tritanopia error/tag',
-  'dark/sapphire tritanopia foreground/string',
-  'dark/sapphire tritanopia keyword/error',
-  'light/amber deuteranopia heading/error',
-  'light/amber deuteranopia parameter/error',
-  'light/amber deuteranopia string/error',
-  'light/amber deuteranopia string/parameter',
-  'light/amber protanopia heading/parameter',
-  'light/amber protanopia heading/string',
-  'light/amber protanopia string/parameter',
-  'light/amber tritanopia function/class',
-  'light/amethyst deuteranopia parameter/error',
-  'light/amethyst deuteranopia string/error',
-  'light/amethyst deuteranopia string/parameter',
-  'light/amethyst protanopia string/parameter',
-  'light/amethyst tritanopia function/class',
-  'light/coral deuteranopia comment/keyword',
-  'light/coral deuteranopia comment/tag',
-  'light/coral deuteranopia parameter/error',
-  'light/coral deuteranopia string/error',
-  'light/coral deuteranopia string/parameter',
-  'light/coral protanopia heading/function',
-  'light/coral protanopia string/parameter',
-  'light/coral tritanopia comment/string',
-  'light/coral tritanopia function/class',
-  'light/jade deuteranopia comment/keyword',
-  'light/jade deuteranopia comment/tag',
-  'light/jade deuteranopia parameter/error',
-  'light/jade deuteranopia string/error',
-  'light/jade deuteranopia string/parameter',
-  'light/jade protanopia string/parameter',
-  'light/jade tritanopia function/class',
-  'light/jade tritanopia heading/function',
-  'light/rose deuteranopia comment/keyword',
-  'light/rose deuteranopia comment/tag',
-  'light/rose deuteranopia heading/function',
-  'light/rose deuteranopia parameter/error',
-  'light/rose deuteranopia string/error',
-  'light/rose deuteranopia string/parameter',
-  'light/rose protanopia comment/class',
-  'light/rose protanopia string/parameter',
-  'light/rose tritanopia function/class',
-  'light/rose tritanopia heading/keyword',
-  'light/rose tritanopia heading/tag',
-  'light/sapphire deuteranopia comment/class',
-  'light/sapphire deuteranopia parameter/error',
-  'light/sapphire deuteranopia string/error',
-  'light/sapphire deuteranopia string/parameter',
-  'light/sapphire protanopia comment/class',
-  'light/sapphire protanopia string/parameter',
-  'light/sapphire tritanopia function/class',
-]);
+const SEVERITIES = [0.5, 0.6, 0.7, 0.8, 0.9, 1.0] as const;
+
+const KNOWN: Record<string, string[]> = {
+  'deuteranomaly comment/class': [
+    'light/amethyst',
+    'light/rose',
+    'light/sapphire',
+  ],
+  'deuteranomaly comment/constant': ['dark/amethyst'],
+  'deuteranomaly comment/error': ['dark/amber'],
+  'deuteranomaly comment/function': ['light/amber', 'light/coral'],
+  'deuteranomaly comment/keyword': [
+    'dark/jade',
+    'light/amber',
+    'light/coral',
+    'light/jade',
+    'light/rose',
+  ],
+  'deuteranomaly comment/tag': [
+    'dark/jade',
+    'light/amber',
+    'light/coral',
+    'light/jade',
+    'light/rose',
+  ],
+  'deuteranomaly foreground/class': [
+    'dark/amber',
+    'dark/amethyst',
+    'dark/coral',
+    'dark/jade',
+    'dark/rose',
+    'dark/sapphire',
+  ],
+  'deuteranomaly function/parameter': [
+    'dark/amber',
+    'dark/amethyst',
+    'dark/coral',
+    'dark/jade',
+    'dark/rose',
+    'dark/sapphire',
+  ],
+  'deuteranomaly heading/comment': ['dark/amethyst'],
+  'deuteranomaly heading/constant': ['light/sapphire'],
+  'deuteranomaly heading/error': ['light/amber', 'light/coral'],
+  'deuteranomaly heading/foreground': ['dark/jade'],
+  'deuteranomaly heading/function': [
+    'dark/amber',
+    'light/amber',
+    'light/coral',
+    'light/rose',
+  ],
+  'deuteranomaly heading/parameter': [
+    'dark/amber',
+    'dark/coral',
+    'light/amber',
+  ],
+  'deuteranomaly heading/string': ['light/amber', 'light/coral'],
+  'deuteranomaly parameter/error': [
+    'dark/amber',
+    'dark/amethyst',
+    'dark/coral',
+    'dark/jade',
+    'dark/rose',
+    'dark/sapphire',
+    'light/amber',
+    'light/amethyst',
+    'light/coral',
+    'light/jade',
+    'light/rose',
+    'light/sapphire',
+  ],
+  'deuteranomaly string/error': [
+    'light/amber',
+    'light/amethyst',
+    'light/coral',
+    'light/jade',
+    'light/rose',
+    'light/sapphire',
+  ],
+  'deuteranomaly string/function': [
+    'dark/amber',
+    'dark/amethyst',
+    'dark/coral',
+    'dark/jade',
+    'dark/rose',
+    'dark/sapphire',
+  ],
+  'deuteranomaly string/parameter': [
+    'dark/amber',
+    'dark/amethyst',
+    'dark/coral',
+    'dark/jade',
+    'dark/rose',
+    'dark/sapphire',
+    'light/amber',
+    'light/amethyst',
+    'light/coral',
+    'light/jade',
+    'light/rose',
+    'light/sapphire',
+  ],
+  'protanomaly comment/class': ['light/rose', 'light/sapphire'],
+  'protanomaly comment/constant': ['dark/amethyst'],
+  'protanomaly comment/error': ['dark/amber', 'light/amber'],
+  'protanomaly comment/keyword': [
+    'dark/amethyst',
+    'dark/rose',
+    'dark/sapphire',
+    'light/amethyst',
+  ],
+  'protanomaly comment/tag': [
+    'dark/amethyst',
+    'dark/rose',
+    'dark/sapphire',
+    'light/amethyst',
+  ],
+  'protanomaly foreground/class': [
+    'dark/amber',
+    'dark/amethyst',
+    'dark/coral',
+    'dark/jade',
+    'dark/rose',
+    'dark/sapphire',
+  ],
+  'protanomaly function/parameter': [
+    'dark/amber',
+    'dark/amethyst',
+    'dark/coral',
+    'dark/jade',
+    'dark/rose',
+    'dark/sapphire',
+    'light/amber',
+    'light/amethyst',
+    'light/coral',
+    'light/jade',
+    'light/rose',
+    'light/sapphire',
+  ],
+  'protanomaly heading/comment': ['dark/amethyst', 'dark/rose'],
+  'protanomaly heading/constant': ['light/sapphire'],
+  'protanomaly heading/error': ['light/coral'],
+  'protanomaly heading/foreground': ['dark/jade'],
+  'protanomaly heading/function': ['dark/amber', 'light/amber', 'light/coral'],
+  'protanomaly heading/parameter': ['light/amber'],
+  'protanomaly heading/string': ['light/amber', 'light/coral'],
+  'protanomaly string/function': [
+    'dark/amber',
+    'dark/amethyst',
+    'dark/coral',
+    'dark/jade',
+    'dark/rose',
+    'dark/sapphire',
+    'light/amber',
+    'light/amethyst',
+    'light/coral',
+    'light/jade',
+    'light/rose',
+    'light/sapphire',
+  ],
+  'protanomaly string/parameter': [
+    'light/amber',
+    'light/amethyst',
+    'light/coral',
+    'light/jade',
+    'light/rose',
+    'light/sapphire',
+  ],
+  'tritanomaly comment/class': ['light/sapphire'],
+  'tritanomaly comment/constant': ['dark/amethyst'],
+  'tritanomaly comment/function': ['light/jade'],
+  'tritanomaly comment/string': ['light/coral', 'light/rose'],
+  'tritanomaly error/tag': [
+    'dark/amber',
+    'dark/amethyst',
+    'dark/coral',
+    'dark/jade',
+    'dark/rose',
+    'dark/sapphire',
+  ],
+  'tritanomaly foreground/string': [
+    'dark/amber',
+    'dark/amethyst',
+    'dark/coral',
+    'dark/jade',
+    'dark/rose',
+    'dark/sapphire',
+  ],
+  'tritanomaly function/class': [
+    'dark/amber',
+    'dark/amethyst',
+    'dark/coral',
+    'dark/jade',
+    'dark/rose',
+    'dark/sapphire',
+    'light/amber',
+    'light/amethyst',
+    'light/coral',
+    'light/jade',
+    'light/rose',
+    'light/sapphire',
+  ],
+  'tritanomaly heading/comment': [
+    'dark/amethyst',
+    'light/coral',
+    'light/jade',
+    'light/sapphire',
+  ],
+  'tritanomaly heading/error': ['dark/rose', 'light/rose'],
+  'tritanomaly heading/foreground': ['dark/amber'],
+  'tritanomaly heading/function': ['dark/jade', 'light/jade'],
+  'tritanomaly heading/keyword': ['dark/coral', 'light/rose'],
+  'tritanomaly heading/parameter': ['light/rose'],
+  'tritanomaly heading/string': ['light/coral'],
+  'tritanomaly heading/tag': ['dark/coral', 'light/rose'],
+  'tritanomaly keyword/error': [
+    'dark/amber',
+    'dark/amethyst',
+    'dark/coral',
+    'dark/jade',
+    'dark/rose',
+    'dark/sapphire',
+  ],
+  'tritanomaly keyword/parameter': [
+    'light/amber',
+    'light/amethyst',
+    'light/coral',
+    'light/jade',
+    'light/rose',
+    'light/sapphire',
+  ],
+  'tritanomaly parameter/error': [
+    'light/amber',
+    'light/amethyst',
+    'light/coral',
+    'light/jade',
+    'light/rose',
+    'light/sapphire',
+  ],
+  'tritanomaly parameter/tag': [
+    'light/amber',
+    'light/amethyst',
+    'light/coral',
+    'light/jade',
+    'light/rose',
+    'light/sapphire',
+  ],
+};
 
 type Rgb = [number, number, number];
 
@@ -195,11 +374,14 @@ const toSrgb = (v: number) => {
   return Math.min(255, Math.max(0, n * 255));
 };
 
-function simulate(rgb: Rgb, deficiency: keyof typeof DEFICIENCIES): Rgb {
-  const m = DEFICIENCIES[deficiency];
+function simulate(rgb: Rgb, matrix: readonly number[]): Rgb {
   const l = rgb.map(toLinear);
   return [0, 1, 2].map((i) =>
-    toSrgb(m[i][0] * l[0] + m[i][1] * l[1] + m[i][2] * l[2]),
+    toSrgb(
+      matrix[i * 3] * l[0] +
+        matrix[i * 3 + 1] * l[1] +
+        matrix[i * 3 + 2] * l[2],
+    ),
   ) as Rgb;
 }
 
@@ -213,10 +395,74 @@ function toLab([r, g, b]: Rgb): Rgb {
   return [116 * Y - 16, 500 * (X - Y), 200 * (Y - Z)];
 }
 
-function deltaE(a: Rgb, b: Rgb): number {
-  const [l1, a1, b1] = toLab(a);
-  const [l2, a2, b2] = toLab(b);
-  return Math.hypot(l1 - l2, a1 - a2, b1 - b2);
+const rad = (d: number) => (d * Math.PI) / 180;
+const deg = (r: number) => (r * 180) / Math.PI;
+
+/**
+ * CIEDE2000, Sharma, Wu & Dalal (2005) formulation, kL = kC = kH = 1.
+ * Verified against all of that paper's reference vectors.
+ */
+function deltaE(rgbA: Rgb, rgbB: Rgb): number {
+  const [L1, a1, b1] = toLab(rgbA);
+  const [L2, a2, b2] = toLab(rgbB);
+
+  const C1 = Math.hypot(a1, b1);
+  const C2 = Math.hypot(a2, b2);
+  const cBar = (C1 + C2) / 2;
+  const G = 0.5 * (1 - Math.sqrt(cBar ** 7 / (cBar ** 7 + 25 ** 7)));
+
+  const ap1 = (1 + G) * a1;
+  const ap2 = (1 + G) * a2;
+  const cp1 = Math.hypot(ap1, b1);
+  const cp2 = Math.hypot(ap2, b2);
+
+  const hue = (b: number, ap: number) => {
+    if (b === 0 && ap === 0) return 0;
+    const h = deg(Math.atan2(b, ap));
+    return h >= 0 ? h : h + 360;
+  };
+  const hp1 = hue(b1, ap1);
+  const hp2 = hue(b2, ap2);
+
+  const dLp = L2 - L1;
+  const dCp = cp2 - cp1;
+
+  let dhp: number;
+  if (cp1 * cp2 === 0) dhp = 0;
+  else if (Math.abs(hp2 - hp1) <= 180) dhp = hp2 - hp1;
+  else if (hp2 - hp1 > 180) dhp = hp2 - hp1 - 360;
+  else dhp = hp2 - hp1 + 360;
+  const dHp = 2 * Math.sqrt(cp1 * cp2) * Math.sin(rad(dhp) / 2);
+
+  const lBar = (L1 + L2) / 2;
+  const cpBar = (cp1 + cp2) / 2;
+
+  let hpBar: number;
+  if (cp1 * cp2 === 0) hpBar = hp1 + hp2;
+  else if (Math.abs(hp1 - hp2) <= 180) hpBar = (hp1 + hp2) / 2;
+  else if (hp1 + hp2 < 360) hpBar = (hp1 + hp2 + 360) / 2;
+  else hpBar = (hp1 + hp2 - 360) / 2;
+
+  const T =
+    1 -
+    0.17 * Math.cos(rad(hpBar - 30)) +
+    0.24 * Math.cos(rad(2 * hpBar)) +
+    0.32 * Math.cos(rad(3 * hpBar + 6)) -
+    0.2 * Math.cos(rad(4 * hpBar - 63));
+
+  const dTheta = 30 * Math.exp(-(((hpBar - 275) / 25) ** 2));
+  const rC = 2 * Math.sqrt(cpBar ** 7 / (cpBar ** 7 + 25 ** 7));
+  const sL = 1 + (0.015 * (lBar - 50) ** 2) / Math.sqrt(20 + (lBar - 50) ** 2);
+  const sC = 1 + 0.045 * cpBar;
+  const sH = 1 + 0.015 * cpBar * T;
+  const rT = -Math.sin(rad(2 * dTheta)) * rC;
+
+  return Math.sqrt(
+    (dLp / sL) ** 2 +
+      (dCp / sC) ** 2 +
+      (dHp / sH) ** 2 +
+      rT * (dCp / sC) * (dHp / sH),
+  );
 }
 
 function blockVars(selector: RegExp): Record<string, string> {
@@ -240,8 +486,14 @@ function selectorFor(mode: 'light' | 'dark', name: string): RegExp {
     : new RegExp(`${base}${attribute}`);
 }
 
-function collapsedPairs(): string[] {
-  const found: string[] = [];
+/**
+ * Conflict -> the palettes it occurs in. A pair counts as collapsed if it is
+ * indistinguishable at any severity, recorded once per deficiency rather than
+ * once per severity: the reader either loses the distinction or does not.
+ */
+function collapsedConflicts(): Record<string, string[]> {
+  const found: Record<string, string[]> = {};
+
   for (const mode of ['light', 'dark'] as const) {
     for (const name of THEMES) {
       const vars = blockVars(selectorFor(mode, name));
@@ -253,23 +505,31 @@ function collapsedPairs(): string[] {
         for (let j = i + 1; j < colors.length; j++) {
           const [nameA, a] = colors[i];
           const [nameB, b] = colors[j];
+          // Tokens that already share a colour are not a collapse to fix.
           if (deltaE(a, b) < DISTINCT) continue;
 
-          for (const deficiency of Object.keys(DEFICIENCIES) as Array<
-            keyof typeof DEFICIENCIES
+          for (const deficiency of Object.keys(CVD_MATRICES) as Array<
+            keyof typeof CVD_MATRICES
           >) {
-            if (
-              deltaE(simulate(a, deficiency), simulate(b, deficiency)) <
-              DISTINCT
-            ) {
-              found.push(`${mode}/${name} ${deficiency} ${nameA}/${nameB}`);
+            for (const severity of SEVERITIES) {
+              const matrix = CVD_MATRICES[deficiency][severity];
+              if (
+                deltaE(simulate(a, matrix), simulate(b, matrix)) >= DISTINCT
+              ) {
+                continue;
+              }
+              const conflict = `${deficiency} ${nameA}/${nameB}`;
+              (found[conflict] ??= []).push(`${mode}/${name}`);
+              break;
             }
           }
         }
       }
     }
   }
-  return found.sort();
+
+  for (const palettes of Object.values(found)) palettes.sort();
+  return found;
 }
 
 /**
@@ -285,40 +545,55 @@ const NON_COLOUR_CUES: Record<string, string> = {
   error: 'wavy underline',
 };
 
-function isMitigated(pair: string): boolean {
-  const [a, b] = pair.split(' ').at(-1)!.split('/');
+function isMitigated(conflict: string): boolean {
+  const [a, b] = conflict.split(' ')[1].split('/');
   return (NON_COLOUR_CUES[a] ?? '') !== (NON_COLOUR_CUES[b] ?? '');
 }
 
 describe('syntax colours under colour vision deficiency', () => {
-  const collapsed = collapsedPairs();
+  const collapsed = collapsedConflicts();
 
-  it('introduces no token pair that was not already known to collapse', () => {
-    expect(collapsed.filter((pair) => !KNOWN.has(pair))).toEqual([]);
+  it('introduces no collapse that is not already recorded', () => {
+    const unrecorded: string[] = [];
+    for (const [conflict, palettes] of Object.entries(collapsed)) {
+      for (const palette of palettes) {
+        if (!KNOWN[conflict]?.includes(palette)) {
+          unrecorded.push(`${conflict} in ${palette}`);
+        }
+      }
+    }
+    expect(unrecorded).toEqual([]);
   });
 
   it('has no stale entries, so the known list shrinks deliberately', () => {
-    const seen = new Set(collapsed);
-    expect([...KNOWN].filter((pair) => !seen.has(pair))).toEqual([]);
+    const stale: string[] = [];
+    for (const [conflict, palettes] of Object.entries(KNOWN)) {
+      for (const palette of palettes) {
+        if (!collapsed[conflict]?.includes(palette)) {
+          stale.push(`${conflict} in ${palette}`);
+        }
+      }
+    }
+    expect(stale).toEqual([]);
   });
 
-  // The count that actually matters. Everything else in KNOWN survives on
-  // italics or a wavy underline; these are distinguishable by hue alone, so a
-  // reader with colour vision deficiency has nothing else to go on.
+  // The count that actually matters. Everything else survives on italics or a
+  // wavy underline; these are distinguishable by hue alone, so a reader with
+  // colour vision deficiency has nothing else to go on.
   //
-  // Went from 42 to 54 when headings became syntax-heading. Those collisions
-  // are not new: headings were drawn in --primary, which this file never
-  // measured, so naming the colour brought existing debt into view rather than
-  // adding any.
-  it('adds no colour-only collapse beyond the recorded 54', () => {
-    const bare = collapsed.filter((pair) => !isMitigated(pair));
-    expect(bare.length).toBeLessThanOrEqual(54);
+  // 124 of 207. The palette did not get worse: this is what switching from
+  // dE76 to CIEDE2000 revealed was already there.
+  it('adds no colour-only collapse beyond the recorded 124', () => {
+    const bare = Object.entries(collapsed)
+      .filter(([conflict]) => !isMitigated(conflict))
+      .reduce((total, [, palettes]) => total + palettes.length, 0);
+    expect(bare).toBeLessThanOrEqual(124);
   });
 
   it('keeps error distinguishable by something other than hue', () => {
-    const bareErrors = collapsed
-      .filter((pair) => pair.includes('error'))
-      .filter((pair) => !isMitigated(pair));
+    const bareErrors = Object.keys(collapsed)
+      .filter((conflict) => conflict.includes('error'))
+      .filter((conflict) => !isMitigated(conflict));
     expect(bareErrors).toEqual([]);
   });
 });

--- a/tests/unit/theme-contrast.test.ts
+++ b/tests/unit/theme-contrast.test.ts
@@ -8,9 +8,9 @@ import { describe, it, expect } from 'vitest';
  * with the very dark Sapphire background explicitly covered.
  */
 /**
- * Newlines are normalised before matching. The repository has no .gitattributes,
- * so this file arrives CRLF on a Windows checkout and every selector lookup
- * below would miss, failing the whole suite with "missing CSS block".
+ * Newlines are normalised before matching. .gitattributes pins this repository
+ * to LF, but a checkout configured otherwise would arrive CRLF and every
+ * selector lookup below would miss, failing the suite with "missing CSS block".
  */
 const css = readFileSync(resolve('src/renderer/src/index.css'), 'utf-8').replace(
   /\r\n/g,


### PR DESCRIPTION
#26 says to fix the yardstick before touching the palette, since it decides what the palette work targets. This is that, and nothing else — no colour changed.

## The metric

ΔE76 with a threshold of 10 was flagged in the issue as a heuristic. It is worse than that: it disagrees with CIEDE2000 badly on saturated colours, and it was calling pairs distinct that are not.

CIEDE2000 is the Sharma, Wu & Dalal formulation, checked against all of that paper's reference vectors before I trusted a single number out of it.

## The threshold

I did not want to swap one guessed constant for another, so I rendered the pairs and looked at them — simulated colours, drawn as interleaved tokens in a line of code rather than as swatches:

- below ~9.7 the two tokens in a line are not tellable apart
- separation gets reliable around 10–11

So 10. It landing on the same number as the old ΔE76 threshold is a coincidence, not a translation, and the comment in the file says so. Worth noting the render is the *easiest* possible case — two tokens side by side in one line, where real code scatters them — so if anything this errs generous.

## Severity

The issue asks for anomalous trichromacy rather than only full dichromacy. My first read of the data said this was redundant, because everything collapsing at severity 0.6 also collapsed at 1.0. That was luck at one threshold — across the range, milder severities do turn up collapses that dichromacy misses.

Concretely: `heading/comment` in dark amethyst collapses from 0.5 through 0.8 and separates again by 1.0. Colours can converge partway and pull apart again, so severity 1.0 is not a worst case that covers the rest. Now sweeps 0.5–1.0.

Matrices are pulled from the published colour-science dataset rather than typed from memory — I checked the six the repo already had against it, and they were right, but the other fifteen I would have got wrong.

## The number went up

**95 entries → 207. Colour-only 54 → 124.**

Nothing got worse. This is what the old metric was failing to see, and it's the honest baseline for the actual palette work in step 2.

`KNOWN` is now grouped by conflict rather than a flat list, which makes the shape readable — a conflict listing all twelve palettes is one shared colour pair to fix, a conflict listing one palette is local. 54 conflicts, and the universal ones are obvious at a glance.

## Checked

Mutated a palette value and confirmed both guards fire; the earlier flat list would have passed some of these. 136 unit tests, typecheck, lint, prettier clean.

Refs #26