### PR TITLE
fix(theme): make syntax colours legible on every editor background

### DIFF
--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -5,7 +5,6 @@
 @tailwind utilities;
 
 @layer base {
-
   :root {
     color-scheme: light;
     --radius: 1.35rem;
@@ -55,7 +54,7 @@
     --shadow-panel: 0 18px 44px hsl(var(--primary) / 0.2);
   }
 
-/* ==== LIGHT THEMES ==== */
+  /* ==== LIGHT THEMES ==== */
 
   :root,
   :root[data-color-theme='amethyst'] {
@@ -88,16 +87,16 @@
     --editor-text: hsl(var(--foreground));
     --editor-cursor: hsl(var(--primary));
     --editor-active-line: hsl(var(--primary) / 0.07);
-    --editor-selection: hsl(var(--primary) / 0.22);
+    --editor-selection: hsl(var(--primary) / 0.07);
     --syntax-heading: 269 52% 49%;
     --syntax-foreground: 268 24% 18%;
     --syntax-comment: 250 18% 46%;
-    --syntax-string: 45 85% 29.5%;
+    --syntax-string: 45 85% 22%;
     --syntax-keyword: 330 72% 42%;
     --syntax-function: 142 58% 30%;
-    --syntax-class: 182 62% 30%;
+    --syntax-class: 182 62% 29%;
     --syntax-constant: 258 60% 50%;
-    --syntax-parameter: 28 82% 37.5%;
+    --syntax-parameter: 28 82% 35%;
     --syntax-error: 0 70% 46%;
     --syntax-tag: 330 72% 42%;
     --mermaid-primary-color: #dbcafc;
@@ -139,16 +138,16 @@
     --editor-text: hsl(var(--foreground));
     --editor-cursor: hsl(var(--primary));
     --editor-active-line: hsl(var(--primary) / 0.07);
-    --editor-selection: hsl(var(--primary) / 0.22);
+    --editor-selection: hsl(var(--primary) / 0.07);
     --syntax-heading: 349 52% 48.5%;
     --syntax-foreground: 268 24% 18%;
-    --syntax-comment: 330 12% 46%;
-    --syntax-string: 45 85% 29.5%;
+    --syntax-comment: 330 12% 44%;
+    --syntax-string: 45 85% 22%;
     --syntax-keyword: 330 72% 42%;
     --syntax-function: 142 58% 30%;
-    --syntax-class: 182 62% 30%;
+    --syntax-class: 182 62% 29%;
     --syntax-constant: 258 60% 50%;
-    --syntax-parameter: 28 82% 37.5%;
+    --syntax-parameter: 28 82% 29.5%;
     --syntax-error: 0 70% 46%;
     --syntax-tag: 330 72% 42%;
     --mermaid-primary-color: #fccada;
@@ -189,17 +188,17 @@
     --success-foreground: 150 49% 30%;
     --editor-text: hsl(var(--foreground));
     --editor-cursor: hsl(var(--primary));
-    --editor-active-line: hsl(var(--primary) / 0.07);
-    --editor-selection: hsl(var(--primary) / 0.22);
+    --editor-active-line: hsl(var(--primary) / 0.08);
+    --editor-selection: hsl(var(--primary) / 0.09);
     --syntax-heading: 189 52% 34.5%;
     --syntax-foreground: 268 24% 18%;
-    --syntax-comment: 160 18% 40.5%;
-    --syntax-string: 45 85% 29.5%;
+    --syntax-comment: 160 18% 39%;
+    --syntax-string: 45 85% 23%;
     --syntax-keyword: 330 72% 42%;
     --syntax-function: 142 58% 30%;
     --syntax-class: 182 62% 30%;
     --syntax-constant: 258 60% 50%;
-    --syntax-parameter: 28 82% 37.5%;
+    --syntax-parameter: 28 82% 36.5%;
     --syntax-error: 0 70% 46%;
     --syntax-tag: 330 72% 42%;
     --mermaid-primary-color: #cafcfc;
@@ -241,7 +240,7 @@
     --editor-text: hsl(var(--foreground));
     --editor-cursor: hsl(var(--primary));
     --editor-active-line: hsl(var(--primary) / 0.07);
-    --editor-selection: hsl(var(--primary) / 0.22);
+    --editor-selection: hsl(var(--primary) / 0.07);
     --syntax-heading: 79 52% 31.5%;
     --syntax-foreground: 268 24% 18%;
     --syntax-comment: 60 12% 32.5%;
@@ -291,17 +290,17 @@
     --success-foreground: 150 49% 30%;
     --editor-text: hsl(var(--foreground));
     --editor-cursor: hsl(var(--primary));
-    --editor-active-line: hsl(var(--primary) / 0.07);
-    --editor-selection: hsl(var(--primary) / 0.22);
-    --syntax-heading: 29 52% 39%;
+    --editor-active-line: hsl(var(--primary) / 0.085);
+    --editor-selection: hsl(var(--primary) / 0.095);
+    --syntax-heading: 29 52% 38.5%;
     --syntax-foreground: 268 24% 18%;
-    --syntax-comment: 10 18% 46%;
-    --syntax-string: 45 85% 29.5%;
+    --syntax-comment: 10 18% 44.5%;
+    --syntax-string: 45 85% 22.5%;
     --syntax-keyword: 330 72% 42%;
     --syntax-function: 142 58% 30%;
-    --syntax-class: 182 62% 30%;
+    --syntax-class: 182 62% 29.5%;
     --syntax-constant: 258 60% 50%;
-    --syntax-parameter: 28 82% 37.5%;
+    --syntax-parameter: 28 82% 36%;
     --syntax-error: 0 70% 46%;
     --syntax-tag: 330 72% 42%;
     --mermaid-primary-color: #fcdbca;
@@ -343,16 +342,16 @@
     --editor-text: hsl(var(--foreground));
     --editor-cursor: hsl(var(--primary));
     --editor-active-line: hsl(var(--primary) / 0.07);
-    --editor-selection: hsl(var(--primary) / 0.22);
+    --editor-selection: hsl(var(--primary) / 0.07);
     --syntax-heading: 229 52% 49%;
     --syntax-foreground: 268 24% 18%;
-    --syntax-comment: 210 18% 45%;
-    --syntax-string: 45 85% 29.5%;
+    --syntax-comment: 210 18% 42.5%;
+    --syntax-string: 45 85% 22%;
     --syntax-keyword: 330 72% 42%;
     --syntax-function: 142 58% 30%;
-    --syntax-class: 182 62% 30%;
+    --syntax-class: 182 62% 29%;
     --syntax-constant: 258 60% 50%;
-    --syntax-parameter: 28 82% 37.5%;
+    --syntax-parameter: 28 82% 35.5%;
     --syntax-error: 0 70% 46%;
     --syntax-tag: 330 72% 42%;
     --mermaid-primary-color: #cadafc;
@@ -364,7 +363,7 @@
     --mermaid-edge-label-background: #f4f7ff;
   }
 
-/* ==== DARK THEMES ==== */
+  /* ==== DARK THEMES ==== */
 
   .dark,
   .dark[data-color-theme='amethyst'] {
@@ -397,15 +396,15 @@
     --editor-text: hsl(var(--foreground));
     --editor-cursor: hsl(var(--primary));
     --editor-active-line: hsl(244 25% 25%);
-    --editor-selection: hsl(245 15% 30%);
+    --editor-selection: hsl(245 15% 23%);
     --syntax-heading: 250 100% 77.5%;
     --syntax-foreground: 60 30% 96%;
-    --syntax-comment: 244 31% 63%;
+    --syntax-comment: 244 31% 69%;
     --syntax-string: 60 100% 75%;
     --syntax-keyword: 330 100% 75%;
     --syntax-function: 115 100% 75%;
     --syntax-class: 170 100% 75%;
-    --syntax-constant: 250 100% 75%;
+    --syntax-constant: 250 100% 77.5%;
     --syntax-parameter: 35 100% 75%;
     --syntax-error: 10 100% 75%;
     --syntax-tag: 330 100% 75%;
@@ -448,15 +447,15 @@
     --editor-text: hsl(var(--foreground));
     --editor-cursor: hsl(var(--primary));
     --editor-active-line: hsl(289 25% 25%);
-    --editor-selection: hsl(290 15% 30%);
+    --editor-selection: hsl(290 15% 24%);
     --syntax-heading: 330 100% 75%;
     --syntax-foreground: 60 30% 96%;
-    --syntax-comment: 288 31% 59.5%;
+    --syntax-comment: 288 31% 68.5%;
     --syntax-string: 60 100% 75%;
     --syntax-keyword: 330 100% 75%;
     --syntax-function: 115 100% 75%;
     --syntax-class: 170 100% 75%;
-    --syntax-constant: 250 100% 75%;
+    --syntax-constant: 250 100% 79.5%;
     --syntax-parameter: 35 100% 75%;
     --syntax-error: 10 100% 75%;
     --syntax-tag: 330 100% 75%;
@@ -499,18 +498,18 @@
     --editor-text: hsl(var(--foreground));
     --editor-cursor: hsl(var(--primary));
     --editor-active-line: hsl(169 25% 25%);
-    --editor-selection: hsl(170 15% 30%);
+    --editor-selection: hsl(170 15% 26.5%);
     --syntax-heading: 170 100% 75%;
     --syntax-foreground: 60 30% 96%;
-    --syntax-comment: 168 25% 55%;
+    --syntax-comment: 168 25% 68%;
     --syntax-string: 60 100% 75%;
-    --syntax-keyword: 330 100% 75%;
+    --syntax-keyword: 330 100% 80.5%;
     --syntax-function: 115 100% 75%;
     --syntax-class: 170 100% 75%;
-    --syntax-constant: 250 100% 75%;
+    --syntax-constant: 250 100% 84.5%;
     --syntax-parameter: 35 100% 75%;
-    --syntax-error: 10 100% 75%;
-    --syntax-tag: 330 100% 75%;
+    --syntax-error: 10 100% 78%;
+    --syntax-tag: 330 100% 80.5%;
     --mermaid-primary-color: #254f53;
     --mermaid-primary-text-color: #dfffff;
     --mermaid-primary-border-color: #93f4f3;
@@ -550,18 +549,18 @@
     --editor-text: hsl(var(--foreground));
     --editor-cursor: hsl(var(--primary));
     --editor-active-line: hsl(49 25% 25%);
-    --editor-selection: hsl(50 15% 30%);
+    --editor-selection: hsl(50 15% 26%);
     --syntax-heading: 60 100% 75%;
     --syntax-foreground: 60 30% 96%;
-    --syntax-comment: 48 25% 55%;
+    --syntax-comment: 48 25% 68%;
     --syntax-string: 60 100% 75%;
-    --syntax-keyword: 330 100% 75%;
+    --syntax-keyword: 330 100% 80.5%;
     --syntax-function: 115 100% 75%;
     --syntax-class: 170 100% 75%;
-    --syntax-constant: 250 100% 75%;
+    --syntax-constant: 250 100% 84.5%;
     --syntax-parameter: 35 100% 75%;
-    --syntax-error: 10 100% 75%;
-    --syntax-tag: 330 100% 75%;
+    --syntax-error: 10 100% 78%;
+    --syntax-tag: 330 100% 80.5%;
     --mermaid-primary-color: #485325;
     --mermaid-primary-text-color: #f9ffdf;
     --mermaid-primary-border-color: #e5f493;
@@ -601,15 +600,15 @@
     --editor-text: hsl(var(--foreground));
     --editor-cursor: hsl(var(--primary));
     --editor-active-line: hsl(356 25% 25%);
-    --editor-selection: hsl(355 15% 30%);
+    --editor-selection: hsl(355 15% 24%);
     --syntax-heading: 10 100% 75%;
     --syntax-foreground: 60 30% 96%;
-    --syntax-comment: 356 25% 59.5%;
+    --syntax-comment: 356 25% 68%;
     --syntax-string: 60 100% 75%;
     --syntax-keyword: 330 100% 75%;
     --syntax-function: 115 100% 75%;
     --syntax-class: 170 100% 75%;
-    --syntax-constant: 250 100% 75%;
+    --syntax-constant: 250 100% 79%;
     --syntax-parameter: 35 100% 75%;
     --syntax-error: 10 100% 75%;
     --syntax-tag: 330 100% 75%;
@@ -652,15 +651,15 @@
     --editor-text: hsl(var(--foreground));
     --editor-cursor: hsl(var(--primary));
     --editor-active-line: hsl(210 25% 25%);
-    --editor-selection: hsl(209 15% 30%);
+    --editor-selection: hsl(209 15% 25%);
     --syntax-heading: 210 100% 75%;
     --syntax-foreground: 60 30% 96%;
-    --syntax-comment: 211 25% 55%;
+    --syntax-comment: 211 25% 68%;
     --syntax-string: 60 100% 75%;
     --syntax-keyword: 330 100% 75%;
     --syntax-function: 115 100% 75%;
     --syntax-class: 170 100% 75%;
-    --syntax-constant: 250 100% 75%;
+    --syntax-constant: 250 100% 81%;
     --syntax-parameter: 35 100% 75%;
     --syntax-error: 10 100% 75%;
     --syntax-tag: 330 100% 75%;
@@ -672,7 +671,6 @@
     --mermaid-tertiary-color: #111623;
     --mermaid-edge-label-background: #111623;
   }
-
 
   * {
     @apply border-border;

--- a/tests/e2e/axe.test.ts
+++ b/tests/e2e/axe.test.ts
@@ -29,12 +29,6 @@ const TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
  * this set fails the run.
  */
 const ACCEPTED: Record<string, string> = {
-  // What remains is one token on the active line background: the heading colour
-  // is 4.06:1 against it in dark amethyst. The active line is a different root
-  // cause from the muted-foreground fix, and every token sits on it when the
-  // caret is there, so it needs the palette solved against that surface too.
-  // Measured and tracked separately.
-  'color-contrast': 'syntax tokens on the active line, tracked separately',
   // CodeMirror's scroller is not focusable itself, but the contenteditable it
   // wraps is, and moving the caret scrolls it. Keyboard users are not stranded.
   'scrollable-region-focusable': 'cm-scroller scrolls via the caret',
@@ -46,9 +40,14 @@ const ACCEPTED: Record<string, string> = {
  * low enough that a new batch of violations cannot hide inside it.
  *
  * Was 40 while dark sat at 33. Fixing muted-foreground dropped dark to 12 and
- * light to 6, so the ceiling comes down with it.
+ * light to 6; solving the palette against the active line and the selection
+ * took color-contrast off the accepted list entirely, leaving 6 on each.
+ *
+ * Worth knowing what this does not prove: axe only ever scans the default
+ * amethyst palette. The other five are covered by theme-contrast.test.ts,
+ * which measures all twelve against all three editor backgrounds.
  */
-const ACCEPTED_NODE_CAP = 15;
+const ACCEPTED_NODE_CAP = 8;
 
 type Violation = {
   id: string;

--- a/tests/helpers/theme-colors.ts
+++ b/tests/helpers/theme-colors.ts
@@ -1,0 +1,242 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Colour maths shared by the theme test suites. Both of them read index.css
+ * directly and reason about the same palettes, and CIEDE2000 in particular is
+ * long enough that a second copy would drift from the first.
+ */
+
+export type Rgb = [number, number, number];
+
+export const THEMES = [
+  'amethyst',
+  'rose',
+  'jade',
+  'amber',
+  'coral',
+  'sapphire',
+];
+
+/**
+ * Newlines are normalised before matching. .gitattributes pins this repository
+ * to LF, but a checkout configured otherwise would arrive CRLF and every
+ * selector lookup would miss, failing the suite with "missing CSS block".
+ */
+export const themeCss = readFileSync(
+  resolve('src/renderer/src/index.css'),
+  'utf-8',
+).replace(/\r\n/g, '\n');
+
+/**
+ * Matched as a pattern rather than a literal so reindenting index.css cannot
+ * quietly break the lookup.
+ */
+function selectorFor(mode: 'light' | 'dark', name: string): RegExp {
+  const base = mode === 'dark' ? '\\.dark' : ':root';
+  const attribute = `\\[data-color-theme='${name}'\\]`;
+
+  // Amethyst is also the default, so it heads a two-selector rule.
+  return name === 'amethyst'
+    ? new RegExp(`${base},\\s*${base}${attribute}`)
+    : new RegExp(`${base}${attribute}`);
+}
+
+/** Every custom property declared by one palette. */
+export function paletteVars(
+  mode: 'light' | 'dark',
+  name: string,
+): Record<string, string> {
+  const selector = selectorFor(mode, name);
+  const match = selector.exec(themeCss);
+  if (!match) throw new Error(`missing CSS block for ${selector}`);
+  const open = themeCss.indexOf('{', match.index);
+  const close = themeCss.indexOf('}', open);
+  const vars: Record<string, string> = {};
+  for (const line of themeCss.slice(open + 1, close).split('\n')) {
+    const m = line.match(/--([\w-]+):\s*([^;]+);/);
+    if (m) vars[m[1]] = m[2].trim();
+  }
+  return vars;
+}
+
+export function hslTripletToRgb(triplet: string): Rgb {
+  const m = triplet.trim().match(/^([\d.]+)\s+([\d.]+)%\s+([\d.]+)%$/);
+  if (!m) throw new Error(`not an HSL triplet: "${triplet}"`);
+  const h = parseFloat(m[1]);
+  const s = parseFloat(m[2]) / 100;
+  const l = parseFloat(m[3]) / 100;
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const mm = l - c / 2;
+  let rgb: Rgb = [0, 0, 0];
+  if (h < 60) rgb = [c, x, 0];
+  else if (h < 120) rgb = [x, c, 0];
+  else if (h < 180) rgb = [0, c, x];
+  else if (h < 240) rgb = [0, x, c];
+  else if (h < 300) rgb = [x, 0, c];
+  else rgb = [c, 0, x];
+  return rgb.map((v) => (v + mm) * 255) as Rgb;
+}
+
+export const toLinear = (v: number) => {
+  const n = v / 255;
+  return n <= 0.04045 ? n / 12.92 : ((n + 0.055) / 1.055) ** 2.4;
+};
+
+export const toSrgb = (v: number) => {
+  const n =
+    v <= 0.0031308
+      ? v * 12.92
+      : 1.055 * Math.pow(Math.max(v, 0), 1 / 2.4) - 0.055;
+  return Math.min(255, Math.max(0, n * 255));
+};
+
+export function luminance([r, g, b]: Rgb): number {
+  return 0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
+}
+
+export function contrast(a: Rgb, b: Rgb): number {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/** Source-over composite of a translucent colour on an opaque backdrop. */
+export function over(fg: Rgb, bg: Rgb, alpha: number): Rgb {
+  return fg.map((c, i) => c * alpha + bg[i] * (1 - alpha)) as Rgb;
+}
+
+/**
+ * Resolves an editor layer, which is written either as an opaque `hsl()` or as
+ * a translucent `hsl(var(--token) / alpha)` that composites over the surface.
+ */
+export function resolveEditorLayer(
+  raw: string,
+  vars: Record<string, string>,
+  surface: Rgb,
+): Rgb {
+  const opaque = raw.match(/^hsl\(([\d.]+)\s+([\d.]+)%\s+([\d.]+)%\)$/);
+  if (opaque) {
+    return hslTripletToRgb(`${opaque[1]} ${opaque[2]}% ${opaque[3]}%`);
+  }
+  const tinted = raw.match(/^hsl\(var\(--([\w-]+)\)\s*\/\s*([\d.]+)\)$/);
+  if (tinted) {
+    return over(
+      hslTripletToRgb(vars[tinted[1]]),
+      surface,
+      parseFloat(tinted[2]),
+    );
+  }
+  throw new Error(`unrecognised editor layer: "${raw}"`);
+}
+
+/**
+ * Every opaque background a syntax token is drawn on. The plain surface most
+ * of the time, the active line whenever the caret is on it, the selection
+ * whenever it is selected.
+ */
+export function editorBackgrounds(
+  vars: Record<string, string>,
+): Record<string, Rgb> {
+  const surface = hslTripletToRgb(vars['editor-surface']);
+  return {
+    'editor surface': surface,
+    'active line': resolveEditorLayer(
+      vars['editor-active-line'],
+      vars,
+      surface,
+    ),
+    selection: resolveEditorLayer(vars['editor-selection'], vars, surface),
+  };
+}
+
+export function simulate(rgb: Rgb, matrix: readonly number[]): Rgb {
+  const l = rgb.map(toLinear);
+  return [0, 1, 2].map((i) =>
+    toSrgb(
+      matrix[i * 3] * l[0] +
+        matrix[i * 3 + 1] * l[1] +
+        matrix[i * 3 + 2] * l[2],
+    ),
+  ) as Rgb;
+}
+
+function toLab([r, g, b]: Rgb): Rgb {
+  const [R, G, B] = [r, g, b].map(toLinear);
+  let X = (0.4124 * R + 0.3576 * G + 0.1805 * B) / 0.95047;
+  let Y = 0.2126 * R + 0.7152 * G + 0.0722 * B;
+  let Z = (0.0193 * R + 0.1192 * G + 0.9505 * B) / 1.08883;
+  const f = (t: number) => (t > 0.008856 ? Math.cbrt(t) : 7.787 * t + 16 / 116);
+  [X, Y, Z] = [f(X), f(Y), f(Z)];
+  return [116 * Y - 16, 500 * (X - Y), 200 * (Y - Z)];
+}
+
+const rad = (d: number) => (d * Math.PI) / 180;
+const deg = (r: number) => (r * 180) / Math.PI;
+
+/**
+ * CIEDE2000, Sharma, Wu & Dalal (2005) formulation, kL = kC = kH = 1.
+ * Verified against all of that paper's reference vectors.
+ */
+export function deltaE2000(rgbA: Rgb, rgbB: Rgb): number {
+  const [L1, a1, b1] = toLab(rgbA);
+  const [L2, a2, b2] = toLab(rgbB);
+
+  const C1 = Math.hypot(a1, b1);
+  const C2 = Math.hypot(a2, b2);
+  const cBar = (C1 + C2) / 2;
+  const G = 0.5 * (1 - Math.sqrt(cBar ** 7 / (cBar ** 7 + 25 ** 7)));
+
+  const ap1 = (1 + G) * a1;
+  const ap2 = (1 + G) * a2;
+  const cp1 = Math.hypot(ap1, b1);
+  const cp2 = Math.hypot(ap2, b2);
+
+  const hue = (b: number, ap: number) => {
+    if (b === 0 && ap === 0) return 0;
+    const h = deg(Math.atan2(b, ap));
+    return h >= 0 ? h : h + 360;
+  };
+  const hp1 = hue(b1, ap1);
+  const hp2 = hue(b2, ap2);
+
+  const dLp = L2 - L1;
+  const dCp = cp2 - cp1;
+
+  let dhp: number;
+  if (cp1 * cp2 === 0) dhp = 0;
+  else if (Math.abs(hp2 - hp1) <= 180) dhp = hp2 - hp1;
+  else if (hp2 - hp1 > 180) dhp = hp2 - hp1 - 360;
+  else dhp = hp2 - hp1 + 360;
+  const dHp = 2 * Math.sqrt(cp1 * cp2) * Math.sin(rad(dhp) / 2);
+
+  const lBar = (L1 + L2) / 2;
+  const cpBar = (cp1 + cp2) / 2;
+
+  let hpBar: number;
+  if (cp1 * cp2 === 0) hpBar = hp1 + hp2;
+  else if (Math.abs(hp1 - hp2) <= 180) hpBar = (hp1 + hp2) / 2;
+  else if (hp1 + hp2 < 360) hpBar = (hp1 + hp2 + 360) / 2;
+  else hpBar = (hp1 + hp2 - 360) / 2;
+
+  const T =
+    1 -
+    0.17 * Math.cos(rad(hpBar - 30)) +
+    0.24 * Math.cos(rad(2 * hpBar)) +
+    0.32 * Math.cos(rad(3 * hpBar + 6)) -
+    0.2 * Math.cos(rad(4 * hpBar - 63));
+
+  const dTheta = 30 * Math.exp(-(((hpBar - 275) / 25) ** 2));
+  const rC = 2 * Math.sqrt(cpBar ** 7 / (cpBar ** 7 + 25 ** 7));
+  const sL = 1 + (0.015 * (lBar - 50) ** 2) / Math.sqrt(20 + (lBar - 50) ** 2);
+  const sC = 1 + 0.045 * cpBar;
+  const sH = 1 + 0.015 * cpBar * T;
+  const rT = -Math.sin(rad(2 * dTheta)) * rC;
+
+  return Math.sqrt(
+    (dLp / sL) ** 2 +
+      (dCp / sC) ** 2 +
+      (dHp / sH) ** 2 +
+      rT * (dCp / sC) * (dHp / sH),
+  );
+}

--- a/tests/unit/theme-colorblind.test.ts
+++ b/tests/unit/theme-colorblind.test.ts
@@ -1,6 +1,11 @@
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
 import { describe, it, expect } from 'vitest';
+import {
+  THEMES,
+  deltaE2000,
+  hslTripletToRgb,
+  paletteVars,
+  simulate,
+} from '../helpers/theme-colors';
 
 /**
  * Syntax highlighting has to stay legible for readers with colour vision
@@ -18,12 +23,6 @@ import { describe, it, expect } from 'vitest';
  * suite fails both on a new collapse and on a stale entry, so the list has to
  * shrink deliberately rather than drift.
  */
-const css = readFileSync(
-  resolve('src/renderer/src/index.css'),
-  'utf-8',
-).replace(/\r\n/g, '\n');
-
-const THEMES = ['amethyst', 'rose', 'jade', 'amber', 'coral', 'sapphire'];
 const SYNTAX_KEYS = [
   'syntax-heading',
   'syntax-foreground',
@@ -47,22 +46,17 @@ const SYNTAX_KEYS = [
  * reliable around 10 to 11. Side-by-side text in a single line is the easiest
  * case there is — real code scatters these tokens — so the threshold sits at
  * the optimistic end of what was legible, not beyond it.
- *
- * This replaced dE76 at the same numeric value, which is a coincidence and not
- * a translation: the two metrics disagree sharply on saturated colours, and
- * the swap roughly doubled the recorded debt because dE76 was calling pairs
- * distinct that are not.
  */
 const DISTINCT = 10;
 
 /**
  * Machado, Oliveira & Fernandes (2009), applied in linear RGB, as published in
- * the colour-science dataset. Rows are the flattened 3x3 matrix.
+ * the colour-science dataset. Each row is the flattened 3x3 matrix.
  *
  * Severity 1.0 is dichromacy; lower severities are anomalous trichromacy,
  * which is both milder and far more common. Severity 1.0 is not a worst case
- * that subsumes the rest — `heading/comment` in dark amethyst collapses from
- * 0.5 to 0.8 and separates again by 1.0 — so the whole range is swept.
+ * that subsumes the rest — colours can converge partway along the range and
+ * separate again — so the whole range is swept.
  */
 // prettier-ignore
 const CVD_MATRICES = {
@@ -95,6 +89,7 @@ const CVD_MATRICES = {
 const SEVERITIES = [0.5, 0.6, 0.7, 0.8, 0.9, 1.0] as const;
 
 const KNOWN: Record<string, string[]> = {
+  'deuteranomaly class/tag': ['dark/amber', 'dark/jade'],
   'deuteranomaly comment/class': [
     'light/amethyst',
     'light/rose',
@@ -105,6 +100,8 @@ const KNOWN: Record<string, string[]> = {
   'deuteranomaly comment/function': ['light/amber', 'light/coral'],
   'deuteranomaly comment/keyword': [
     'dark/jade',
+    'dark/rose',
+    'dark/sapphire',
     'light/amber',
     'light/coral',
     'light/jade',
@@ -112,6 +109,8 @@ const KNOWN: Record<string, string[]> = {
   ],
   'deuteranomaly comment/tag': [
     'dark/jade',
+    'dark/rose',
+    'dark/sapphire',
     'light/amber',
     'light/coral',
     'light/jade',
@@ -133,8 +132,8 @@ const KNOWN: Record<string, string[]> = {
     'dark/rose',
     'dark/sapphire',
   ],
-  'deuteranomaly heading/comment': ['dark/amethyst'],
-  'deuteranomaly heading/constant': ['light/sapphire'],
+  'deuteranomaly heading/comment': ['dark/amethyst', 'dark/rose'],
+  'deuteranomaly heading/constant': ['dark/sapphire', 'light/sapphire'],
   'deuteranomaly heading/error': ['light/amber', 'light/coral'],
   'deuteranomaly heading/foreground': ['dark/jade'],
   'deuteranomaly heading/function': [
@@ -143,12 +142,15 @@ const KNOWN: Record<string, string[]> = {
     'light/coral',
     'light/rose',
   ],
+  'deuteranomaly heading/keyword': ['dark/jade'],
   'deuteranomaly heading/parameter': [
     'dark/amber',
     'dark/coral',
     'light/amber',
   ],
   'deuteranomaly heading/string': ['light/amber', 'light/coral'],
+  'deuteranomaly heading/tag': ['dark/jade'],
+  'deuteranomaly keyword/class': ['dark/amber', 'dark/jade'],
   'deuteranomaly parameter/error': [
     'dark/amber',
     'dark/amethyst',
@@ -163,14 +165,7 @@ const KNOWN: Record<string, string[]> = {
     'light/rose',
     'light/sapphire',
   ],
-  'deuteranomaly string/error': [
-    'light/amber',
-    'light/amethyst',
-    'light/coral',
-    'light/jade',
-    'light/rose',
-    'light/sapphire',
-  ],
+  'deuteranomaly string/error': ['light/amber', 'light/jade'],
   'deuteranomaly string/function': [
     'dark/amber',
     'dark/amethyst',
@@ -178,6 +173,7 @@ const KNOWN: Record<string, string[]> = {
     'dark/jade',
     'dark/rose',
     'dark/sapphire',
+    'light/jade',
   ],
   'deuteranomaly string/parameter': [
     'dark/amber',
@@ -187,14 +183,10 @@ const KNOWN: Record<string, string[]> = {
     'dark/rose',
     'dark/sapphire',
     'light/amber',
-    'light/amethyst',
-    'light/coral',
-    'light/jade',
     'light/rose',
-    'light/sapphire',
   ],
   'protanomaly comment/class': ['light/rose', 'light/sapphire'],
-  'protanomaly comment/constant': ['dark/amethyst'],
+  'protanomaly comment/constant': ['dark/amethyst', 'dark/rose'],
   'protanomaly comment/error': ['dark/amber', 'light/amber'],
   'protanomaly comment/keyword': [
     'dark/amethyst',
@@ -208,6 +200,7 @@ const KNOWN: Record<string, string[]> = {
     'dark/sapphire',
     'light/amethyst',
   ],
+  'protanomaly constant/tag': ['dark/amber', 'dark/jade'],
   'protanomaly foreground/class': [
     'dark/amber',
     'dark/amethyst',
@@ -227,16 +220,30 @@ const KNOWN: Record<string, string[]> = {
     'light/amethyst',
     'light/coral',
     'light/jade',
-    'light/rose',
     'light/sapphire',
   ],
   'protanomaly heading/comment': ['dark/amethyst', 'dark/rose'],
-  'protanomaly heading/constant': ['light/sapphire'],
+  'protanomaly heading/constant': ['dark/sapphire', 'light/sapphire'],
   'protanomaly heading/error': ['light/coral'],
   'protanomaly heading/foreground': ['dark/jade'],
   'protanomaly heading/function': ['dark/amber', 'light/amber', 'light/coral'],
   'protanomaly heading/parameter': ['light/amber'],
   'protanomaly heading/string': ['light/amber', 'light/coral'],
+  'protanomaly keyword/constant': ['dark/amber', 'dark/jade'],
+  'protanomaly parameter/error': [
+    'light/amethyst',
+    'light/coral',
+    'light/jade',
+    'light/rose',
+    'light/sapphire',
+  ],
+  'protanomaly string/error': [
+    'light/amethyst',
+    'light/coral',
+    'light/jade',
+    'light/rose',
+    'light/sapphire',
+  ],
   'protanomaly string/function': [
     'dark/amber',
     'dark/amethyst',
@@ -245,11 +252,6 @@ const KNOWN: Record<string, string[]> = {
     'dark/rose',
     'dark/sapphire',
     'light/amber',
-    'light/amethyst',
-    'light/coral',
-    'light/jade',
-    'light/rose',
-    'light/sapphire',
   ],
   'protanomaly string/parameter': [
     'light/amber',
@@ -262,7 +264,7 @@ const KNOWN: Record<string, string[]> = {
   'tritanomaly comment/class': ['light/sapphire'],
   'tritanomaly comment/constant': ['dark/amethyst'],
   'tritanomaly comment/function': ['light/jade'],
-  'tritanomaly comment/string': ['light/coral', 'light/rose'],
+  'tritanomaly comment/string': ['light/coral'],
   'tritanomaly error/tag': [
     'dark/amber',
     'dark/amethyst',
@@ -303,8 +305,6 @@ const KNOWN: Record<string, string[]> = {
   'tritanomaly heading/foreground': ['dark/amber'],
   'tritanomaly heading/function': ['dark/jade', 'light/jade'],
   'tritanomaly heading/keyword': ['dark/coral', 'light/rose'],
-  'tritanomaly heading/parameter': ['light/rose'],
-  'tritanomaly heading/string': ['light/coral'],
   'tritanomaly heading/tag': ['dark/coral', 'light/rose'],
   'tritanomaly keyword/error': [
     'dark/amber',
@@ -323,11 +323,12 @@ const KNOWN: Record<string, string[]> = {
     'light/sapphire',
   ],
   'tritanomaly parameter/error': [
+    'dark/amber',
+    'dark/jade',
     'light/amber',
     'light/amethyst',
     'light/coral',
     'light/jade',
-    'light/rose',
     'light/sapphire',
   ],
   'tritanomaly parameter/tag': [
@@ -340,152 +341,6 @@ const KNOWN: Record<string, string[]> = {
   ],
 };
 
-type Rgb = [number, number, number];
-
-function hslTripletToRgb(triplet: string): Rgb {
-  const m = triplet.trim().match(/^([\d.]+)\s+([\d.]+)%\s+([\d.]+)%$/);
-  if (!m) throw new Error(`not an HSL triplet: "${triplet}"`);
-  const h = parseFloat(m[1]);
-  const s = parseFloat(m[2]) / 100;
-  const l = parseFloat(m[3]) / 100;
-  const c = (1 - Math.abs(2 * l - 1)) * s;
-  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
-  const mm = l - c / 2;
-  let rgb: Rgb = [0, 0, 0];
-  if (h < 60) rgb = [c, x, 0];
-  else if (h < 120) rgb = [x, c, 0];
-  else if (h < 180) rgb = [0, c, x];
-  else if (h < 240) rgb = [0, x, c];
-  else if (h < 300) rgb = [x, 0, c];
-  else rgb = [c, 0, x];
-  return rgb.map((v) => (v + mm) * 255) as Rgb;
-}
-
-const toLinear = (v: number) => {
-  const n = v / 255;
-  return n <= 0.04045 ? n / 12.92 : ((n + 0.055) / 1.055) ** 2.4;
-};
-
-const toSrgb = (v: number) => {
-  const n =
-    v <= 0.0031308
-      ? v * 12.92
-      : 1.055 * Math.pow(Math.max(v, 0), 1 / 2.4) - 0.055;
-  return Math.min(255, Math.max(0, n * 255));
-};
-
-function simulate(rgb: Rgb, matrix: readonly number[]): Rgb {
-  const l = rgb.map(toLinear);
-  return [0, 1, 2].map((i) =>
-    toSrgb(
-      matrix[i * 3] * l[0] +
-        matrix[i * 3 + 1] * l[1] +
-        matrix[i * 3 + 2] * l[2],
-    ),
-  ) as Rgb;
-}
-
-function toLab([r, g, b]: Rgb): Rgb {
-  const [R, G, B] = [r, g, b].map(toLinear);
-  let X = (0.4124 * R + 0.3576 * G + 0.1805 * B) / 0.95047;
-  let Y = 0.2126 * R + 0.7152 * G + 0.0722 * B;
-  let Z = (0.0193 * R + 0.1192 * G + 0.9505 * B) / 1.08883;
-  const f = (t: number) => (t > 0.008856 ? Math.cbrt(t) : 7.787 * t + 16 / 116);
-  [X, Y, Z] = [f(X), f(Y), f(Z)];
-  return [116 * Y - 16, 500 * (X - Y), 200 * (Y - Z)];
-}
-
-const rad = (d: number) => (d * Math.PI) / 180;
-const deg = (r: number) => (r * 180) / Math.PI;
-
-/**
- * CIEDE2000, Sharma, Wu & Dalal (2005) formulation, kL = kC = kH = 1.
- * Verified against all of that paper's reference vectors.
- */
-function deltaE(rgbA: Rgb, rgbB: Rgb): number {
-  const [L1, a1, b1] = toLab(rgbA);
-  const [L2, a2, b2] = toLab(rgbB);
-
-  const C1 = Math.hypot(a1, b1);
-  const C2 = Math.hypot(a2, b2);
-  const cBar = (C1 + C2) / 2;
-  const G = 0.5 * (1 - Math.sqrt(cBar ** 7 / (cBar ** 7 + 25 ** 7)));
-
-  const ap1 = (1 + G) * a1;
-  const ap2 = (1 + G) * a2;
-  const cp1 = Math.hypot(ap1, b1);
-  const cp2 = Math.hypot(ap2, b2);
-
-  const hue = (b: number, ap: number) => {
-    if (b === 0 && ap === 0) return 0;
-    const h = deg(Math.atan2(b, ap));
-    return h >= 0 ? h : h + 360;
-  };
-  const hp1 = hue(b1, ap1);
-  const hp2 = hue(b2, ap2);
-
-  const dLp = L2 - L1;
-  const dCp = cp2 - cp1;
-
-  let dhp: number;
-  if (cp1 * cp2 === 0) dhp = 0;
-  else if (Math.abs(hp2 - hp1) <= 180) dhp = hp2 - hp1;
-  else if (hp2 - hp1 > 180) dhp = hp2 - hp1 - 360;
-  else dhp = hp2 - hp1 + 360;
-  const dHp = 2 * Math.sqrt(cp1 * cp2) * Math.sin(rad(dhp) / 2);
-
-  const lBar = (L1 + L2) / 2;
-  const cpBar = (cp1 + cp2) / 2;
-
-  let hpBar: number;
-  if (cp1 * cp2 === 0) hpBar = hp1 + hp2;
-  else if (Math.abs(hp1 - hp2) <= 180) hpBar = (hp1 + hp2) / 2;
-  else if (hp1 + hp2 < 360) hpBar = (hp1 + hp2 + 360) / 2;
-  else hpBar = (hp1 + hp2 - 360) / 2;
-
-  const T =
-    1 -
-    0.17 * Math.cos(rad(hpBar - 30)) +
-    0.24 * Math.cos(rad(2 * hpBar)) +
-    0.32 * Math.cos(rad(3 * hpBar + 6)) -
-    0.2 * Math.cos(rad(4 * hpBar - 63));
-
-  const dTheta = 30 * Math.exp(-(((hpBar - 275) / 25) ** 2));
-  const rC = 2 * Math.sqrt(cpBar ** 7 / (cpBar ** 7 + 25 ** 7));
-  const sL = 1 + (0.015 * (lBar - 50) ** 2) / Math.sqrt(20 + (lBar - 50) ** 2);
-  const sC = 1 + 0.045 * cpBar;
-  const sH = 1 + 0.015 * cpBar * T;
-  const rT = -Math.sin(rad(2 * dTheta)) * rC;
-
-  return Math.sqrt(
-    (dLp / sL) ** 2 +
-      (dCp / sC) ** 2 +
-      (dHp / sH) ** 2 +
-      rT * (dCp / sC) * (dHp / sH),
-  );
-}
-
-function blockVars(selector: RegExp): Record<string, string> {
-  const match = selector.exec(css);
-  if (!match) throw new Error(`missing CSS block for ${selector}`);
-  const open = css.indexOf('{', match.index);
-  const close = css.indexOf('}', open);
-  const vars: Record<string, string> = {};
-  for (const line of css.slice(open + 1, close).split('\n')) {
-    const m = line.match(/--([\w-]+):\s*([^;]+);/);
-    if (m) vars[m[1]] = m[2].trim();
-  }
-  return vars;
-}
-
-function selectorFor(mode: 'light' | 'dark', name: string): RegExp {
-  const base = mode === 'dark' ? '\\.dark' : ':root';
-  const attribute = `\\[data-color-theme='${name}'\\]`;
-  return name === 'amethyst'
-    ? new RegExp(`${base},\\s*${base}${attribute}`)
-    : new RegExp(`${base}${attribute}`);
-}
-
 /**
  * Conflict -> the palettes it occurs in. A pair counts as collapsed if it is
  * indistinguishable at any severity, recorded once per deficiency rather than
@@ -496,7 +351,7 @@ function collapsedConflicts(): Record<string, string[]> {
 
   for (const mode of ['light', 'dark'] as const) {
     for (const name of THEMES) {
-      const vars = blockVars(selectorFor(mode, name));
+      const vars = paletteVars(mode, name);
       const colors = SYNTAX_KEYS.filter((k) => vars[k]).map(
         (k) => [k.replace('syntax-', ''), hslTripletToRgb(vars[k])] as const,
       );
@@ -506,7 +361,7 @@ function collapsedConflicts(): Record<string, string[]> {
           const [nameA, a] = colors[i];
           const [nameB, b] = colors[j];
           // Tokens that already share a colour are not a collapse to fix.
-          if (deltaE(a, b) < DISTINCT) continue;
+          if (deltaE2000(a, b) < DISTINCT) continue;
 
           for (const deficiency of Object.keys(CVD_MATRICES) as Array<
             keyof typeof CVD_MATRICES
@@ -514,12 +369,13 @@ function collapsedConflicts(): Record<string, string[]> {
             for (const severity of SEVERITIES) {
               const matrix = CVD_MATRICES[deficiency][severity];
               if (
-                deltaE(simulate(a, matrix), simulate(b, matrix)) >= DISTINCT
+                deltaE2000(simulate(a, matrix), simulate(b, matrix)) >= DISTINCT
               ) {
                 continue;
               }
-              const conflict = `${deficiency} ${nameA}/${nameB}`;
-              (found[conflict] ??= []).push(`${mode}/${name}`);
+              (found[`${deficiency} ${nameA}/${nameB}`] ??= []).push(
+                `${mode}/${name}`,
+              );
               break;
             }
           }
@@ -581,13 +437,14 @@ describe('syntax colours under colour vision deficiency', () => {
   // wavy underline; these are distinguishable by hue alone, so a reader with
   // colour vision deficiency has nothing else to go on.
   //
-  // 124 of 207. The palette did not get worse: this is what switching from
-  // dE76 to CIEDE2000 revealed was already there.
-  it('adds no colour-only collapse beyond the recorded 124', () => {
+  // 125 of 220, against 124 before this palette moved. Holding it flat was not
+  // free: raising dark tokens for contrast pushed it to 136, and light strings
+  // were then darkened further than contrast alone required to bring it back.
+  it('adds no colour-only collapse beyond the recorded 125', () => {
     const bare = Object.entries(collapsed)
       .filter(([conflict]) => !isMitigated(conflict))
       .reduce((total, [, palettes]) => total + palettes.length, 0);
-    expect(bare).toBeLessThanOrEqual(124);
+    expect(bare).toBeLessThanOrEqual(125);
   });
 
   it('keeps error distinguishable by something other than hue', () => {

--- a/tests/unit/theme-contrast.test.ts
+++ b/tests/unit/theme-contrast.test.ts
@@ -1,23 +1,18 @@
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
 import { describe, it, expect } from 'vitest';
+import {
+  THEMES,
+  contrast,
+  deltaE2000,
+  editorBackgrounds,
+  hslTripletToRgb,
+  paletteVars,
+} from '../helpers/theme-colors';
 
 /**
  * Guards issue #3's readability requirement: every palette (light and dark)
  * must keep body text and syntax tokens legible against its own surfaces,
  * with the very dark Sapphire background explicitly covered.
  */
-/**
- * Newlines are normalised before matching. .gitattributes pins this repository
- * to LF, but a checkout configured otherwise would arrive CRLF and every
- * selector lookup below would miss, failing the suite with "missing CSS block".
- */
-const css = readFileSync(resolve('src/renderer/src/index.css'), 'utf-8').replace(
-  /\r\n/g,
-  '\n',
-);
-
-const THEMES = ['amethyst', 'rose', 'jade', 'amber', 'coral', 'sapphire'];
 const SYNTAX_KEYS = [
   'syntax-heading',
   'syntax-foreground',
@@ -32,73 +27,10 @@ const SYNTAX_KEYS = [
   'syntax-tag',
 ];
 
-type Rgb = [number, number, number];
-
-function hslTripletToRgb(triplet: string): Rgb {
-  const m = triplet
-    .trim()
-    .match(/^([\d.]+)\s+([\d.]+)%\s+([\d.]+)%$/);
-  if (!m) throw new Error(`not an HSL triplet: "${triplet}"`);
-  const h = parseFloat(m[1]);
-  const s = parseFloat(m[2]) / 100;
-  const l = parseFloat(m[3]) / 100;
-  const c = (1 - Math.abs(2 * l - 1)) * s;
-  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
-  const mm = l - c / 2;
-  let rgb: Rgb = [0, 0, 0];
-  if (h < 60) rgb = [c, x, 0];
-  else if (h < 120) rgb = [x, c, 0];
-  else if (h < 180) rgb = [0, c, x];
-  else if (h < 240) rgb = [0, x, c];
-  else if (h < 300) rgb = [x, 0, c];
-  else rgb = [c, 0, x];
-  return rgb.map((v) => (v + mm) * 255) as Rgb;
-}
-
-function luminance([r, g, b]: Rgb): number {
-  const f = (v: number) => {
-    const n = v / 255;
-    return n <= 0.03928 ? n / 12.92 : ((n + 0.055) / 1.055) ** 2.4;
-  };
-  return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b);
-}
-
-function contrast(a: Rgb, b: Rgb): number {
-  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
-  return (hi + 0.05) / (lo + 0.05);
-}
-
-function blockVars(selector: RegExp): Record<string, string> {
-  const match = selector.exec(css);
-  if (!match) throw new Error(`missing CSS block for ${selector}`);
-  const open = css.indexOf('{', match.index);
-  const close = css.indexOf('}', open);
-  const vars: Record<string, string> = {};
-  for (const line of css.slice(open + 1, close).split('\n')) {
-    const m = line.match(/--([\w-]+):\s*([^;]+);/);
-    if (m) vars[m[1]] = m[2].trim();
-  }
-  return vars;
-}
-
-/**
- * Matched as a pattern rather than a literal so reindenting index.css cannot
- * quietly break the lookup.
- */
-function selectorFor(mode: 'light' | 'dark', name: string): RegExp {
-  const base = mode === 'dark' ? '\\.dark' : ':root';
-  const attribute = `\\[data-color-theme='${name}'\\]`;
-
-  // Amethyst is also the default, so it heads a two-selector rule.
-  return name === 'amethyst'
-    ? new RegExp(`${base},\\s*${base}${attribute}`)
-    : new RegExp(`${base}${attribute}`);
-}
-
 describe('theme contrast (WCAG)', () => {
   for (const mode of ['light', 'dark'] as const) {
     for (const name of THEMES) {
-      const vars = blockVars(selectorFor(mode, name));
+      const vars = paletteVars(mode, name);
 
       it(`${mode}/${name}: body text is legible on the app background`, () => {
         const fg = hslTripletToRgb(vars.foreground);
@@ -125,17 +57,49 @@ describe('theme contrast (WCAG)', () => {
         }
       });
 
-      // 4.5:1 is WCAG AA for normal-size text, which is what code is. The
-      // threshold used to be 3:1, under which every token passed while 18 sat
-      // below the bar issue #4 actually asks for.
-      it(`${mode}/${name}: syntax tokens are legible on the editor surface`, () => {
-        const surface = hslTripletToRgb(vars['editor-surface']);
+      /**
+       * Three backgrounds, not one. Text sits on the plain surface most of the
+       * time, on the active line whenever the caret is on that line, and on the
+       * selection whenever it is selected. Only the first was ever measured, so
+       * tokens tuned against it dropped below AA the moment the caret arrived:
+       * 34 token/background pairs on the active line and 77 on the selection.
+       *
+       * 4.5:1 is WCAG AA for normal-size text, which is what code is.
+       */
+      it(`${mode}/${name}: syntax tokens are legible on every editor background`, () => {
+        const backgrounds = editorBackgrounds(vars);
         for (const key of SYNTAX_KEYS) {
           const token = hslTripletToRgb(vars[key]);
+          for (const [label, background] of Object.entries(backgrounds)) {
+            expect(
+              contrast(token, background),
+              `${key} on the ${label} in ${mode}/${name}`,
+            ).toBeGreaterThanOrEqual(4.5);
+          }
+        }
+      });
+
+      /**
+       * The other half of that trade, and the reason it needs pinning down.
+       *
+       * Contrast against the active line and the selection can always be
+       * satisfied by making them fade into the surface, which is not a fix —
+       * it deletes the feature to pass the test. Selection was softened to buy
+       * the contrast above, so the floor it was softened to is now recorded.
+       *
+       * CIEDE2000 rather than a contrast ratio: these are large blocks of
+       * colour where hue and chroma carry the signal, not thin glyphs where
+       * luminance does. 3 is around where a filled region stops reading as a
+       * distinct band.
+       */
+      it(`${mode}/${name}: editor highlights stay visible against the surface`, () => {
+        const { 'editor surface': surface, ...highlights } =
+          editorBackgrounds(vars);
+        for (const [label, highlight] of Object.entries(highlights)) {
           expect(
-            contrast(token, surface),
-            `${key} in ${mode}/${name}`,
-          ).toBeGreaterThanOrEqual(4.5);
+            deltaE2000(highlight, surface),
+            `the ${label} against the editor surface in ${mode}/${name}`,
+          ).toBeGreaterThanOrEqual(3);
         }
       });
     }


### PR DESCRIPTION
Syntax tokens were tuned against the editor surface, but that is not the only thing behind them. Text sits on the active line whenever the caret is on it, and on the selection whenever it is selected. Neither was ever measured.

| background | pairs below 4.5:1 |
|---|---|
| editor surface | 0 |
| active line | 34 |
| **selection** | **77** |

Selection is the worse of the two and #31 did not mention it at all — I found it once the machinery was out.

## Why the tokens had to move

I tried the cheap fix first: leave the tokens alone and pull the highlights back. It does not work. To keep today's tokens above AA the active line and selection would have to sit at ΔE 0.6–1.7 from the surface, down from 3–14. That is an invisible highlight, so it is not a fix.

## What this does

Tokens answer to the surface and the active line — the two backgrounds you get without asking for them. Selection is then the strongest tint those tokens still clear AA on: **0.22 → ~0.08 alpha** in light palettes, **30% → ~25%** lightness in dark ones.

That puts the compromise on selection strength rather than on comment brightness. Comments are meant to recede, and the full-strict option pushed dark comments **+20 lightness**, which stops them receding at all. This way the largest move is +13 and the character of each palette survives.

Also strengthens the active line in **light coral (ΔE 2.9)** and **light jade (3.2)** — pre-existing, nothing to do with this fix, but they barely read as a highlight and the new visibility guard caught them.

## One thing that got worse before it got better

Raising dark tokens for contrast pushed colour-only CVD collapses **124 → 136**. Light strings are therefore darkened further than contrast alone required, bringing it back to **125**. Roughly flat, and honest about not being free.

Worth recording for #26: the same search unrestricted gets to **89**, well below where we started. It needs to move `foreground`, `string` and `function` in the dark palettes, which is a bigger visual change than belongs in a contrast fix — but it does answer that issue's open question about whether a solution exists. It largely does.

## Guarding both directions

The new contrast test would pass if someone made the highlights vanish, so the highlights are now pinned to a minimum distance from the surface too. That check uses CIEDE2000 rather than a contrast ratio — these are large blocks of colour where hue and chroma carry the signal, not thin glyphs where luminance does.

Colour maths moved to `tests/helpers/theme-colors.ts`; both suites parse the same CSS and both now need CIEDE2000, and a second copy of that formula would drift.

`color-contrast` comes off the axe accepted list entirely, dark going from 12 accepted nodes to 6. I also wrote down there what axe does *not* prove: it only ever scans amethyst. The other five palettes are covered by the unit test, which measures all twelve against all three backgrounds.

## Checked

148 unit, 94 e2e, typecheck, lint, build. Screenshots of dark jade, light coral, dark amethyst and light sapphire with the caret parked and a selection live.

Closes #31