### PR TITLE
ci: check formatting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,24 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Formatting drifts because npm run format is only ever run by hand, and then
+  # only over the files someone happens to be editing. Checked in CI rather than
+  # in the pre-commit hook, which can be skipped.
+  format:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      - run: npx prettier --check .
+
   unit-tests:
     runs-on: ubuntu-latest
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -21,12 +21,7 @@ export type PdfPageSize = 'A4' | 'Letter' | 'Legal' | 'A3';
 export type ExportFont = 'system' | 'serif' | 'mono';
 
 export type ThemeName =
-  | 'amethyst'
-  | 'rose'
-  | 'jade'
-  | 'amber'
-  | 'coral'
-  | 'sapphire';
+  'amethyst' | 'rose' | 'jade' | 'amber' | 'coral' | 'sapphire';
 
 export type PdfMargins = {
   top: number;

--- a/tests/e2e/accessibility.test.ts
+++ b/tests/e2e/accessibility.test.ts
@@ -122,9 +122,9 @@ test.describe('accessibility', () => {
       '[role="group"][aria-labelledby="settings-theme-label"]',
     );
     await expect(themeGroup.locator('button')).toHaveCount(2);
-    await expect(
-      themeGroup.locator('button[aria-pressed="true"]'),
-    ).toHaveCount(1);
+    await expect(themeGroup.locator('button[aria-pressed="true"]')).toHaveCount(
+      1,
+    );
 
     await window.keyboard.press('Escape');
   });

--- a/tests/e2e/aria-snapshot.test.ts
+++ b/tests/e2e/aria-snapshot.test.ts
@@ -20,7 +20,9 @@ test.describe('aria snapshots', () => {
     const snapshot = await window.locator('[role="dialog"]').ariaSnapshot();
 
     // Every labelled group, by accessible name.
-    const groups = [...snapshot.matchAll(/- group "([^"]+)"/g)].map((m) => m[1]);
+    const groups = [...snapshot.matchAll(/- group "([^"]+)"/g)].map(
+      (m) => m[1],
+    );
     expect(groups.length).toBeGreaterThan(0);
 
     // The same text must not also sit in the tree as loose static text: the
@@ -41,7 +43,10 @@ test.describe('aria snapshots', () => {
   test('settings groups expose their controls', async ({ window }) => {
     await window.locator('button[aria-label="Settings"]').click();
 
-    const themeGroup = window.getByRole('group', { name: 'Theme', exact: true });
+    const themeGroup = window.getByRole('group', {
+      name: 'Theme',
+      exact: true,
+    });
     await expect(themeGroup).toMatchAriaSnapshot(`
       - group "Theme":
         - button "Light"


### PR DESCRIPTION
Closes #38, which I filed while working on #17 after a `prettier --write` over a glob reformatted a dozen files I had not touched.

**The number in that issue was wrong and I have corrected it there.** I reported 62 files. On a clean checkout of main it is **3**:

```
src/shared/types.ts
tests/e2e/accessibility.test.ts
tests/e2e/aria-snapshot.test.ts
```

The 62 came from a check against my working tree in a state I cannot reproduce — almost certainly CRLF locally, since `.gitattributes` pins the repo to LF while `core.autocrlf` is `true` on this machine. The committed content was mostly fine.

## What this does

Two commits:

1. `npm run format` — three files, pure reflow, no behaviour change
2. a `format` job running `prettier --check .`

The second is the point. Those three drifted in because nothing looks: the pre-commit hook runs eslint, typecheck and commitlint, and no CI job checked formatting. Put in CI rather than the hook because the hook can be skipped.

It also means the next person running the formatter over a glob gets a clean diff instead of collateral.

## Checked

148 unit, 105 e2e (22 screenshots skip off Linux), typecheck, lint, and `prettier --check .` clean locally — though CI is the real test of that one, since the whole question here is whether my machine and CI agree.