### PR TITLE
fix(editor): mark function and tag names bold

### DIFF
--- a/src/renderer/src/features/editor/lib/highlight-style.ts
+++ b/src/renderer/src/features/editor/lib/highlight-style.ts
@@ -42,9 +42,14 @@ export const markyHighlightStyle = HighlightStyle.define([
   { tag: t.comment, color: color.comment, fontStyle: 'italic' },
   { tag: [t.keyword, t.modifier, t.operatorKeyword], color: color.keyword },
   { tag: [t.string, t.special(t.string), t.regexp], color: color.string },
+  // Bold, not just coloured: function names sit in more colour-vision
+  // collapses than any other token, and weight is the one cue that costs a
+  // reader nothing. Safe to mark because these tags are code-only, so no
+  // markdown ever renders bolder than it did.
   {
     tag: [t.function(t.variableName), t.function(t.propertyName)],
     color: color.function,
+    fontWeight: '700',
   },
   { tag: [t.typeName, t.className, t.namespace], color: color.class },
   {
@@ -55,7 +60,10 @@ export const markyHighlightStyle = HighlightStyle.define([
     tag: [t.propertyName, t.attributeName, t.variableName],
     color: color.parameter,
   },
-  { tag: [t.tagName, t.angleBracket], color: color.tag },
+  // Also bold, and for the same reason. Chosen over keyword, which scores the
+  // same but shares its colour with t.list and would put every bullet marker
+  // in the document in bold.
+  { tag: [t.tagName, t.angleBracket], color: color.tag, fontWeight: '700' },
   { tag: [t.operator, t.punctuation, t.separator], color: color.foreground },
   // Wavy underline rather than colour alone: error collapses into keyword, tag,
   // string and parameter once simulated for colour vision deficiency, and it is

--- a/tests/unit/theme-colorblind.test.ts
+++ b/tests/unit/theme-colorblind.test.ts
@@ -333,21 +333,51 @@ function collapsedConflicts(): Record<string, string[]> {
 }
 
 /**
- * Non-colour cues from highlight-style.ts. A pair whose two tokens carry
- * different cues stays tellable apart even when the colours collapse, so it is
- * not the same risk as a pair distinguished by hue alone.
+ * The non-colour marks each syntax colour appears with, read off
+ * highlight-style.ts. A pair survives a hue collapse only when the two colours
+ * can never be drawn the same way.
  *
- * Keep in step with markyHighlightStyle: a cue removed there without being
- * removed here would overstate how safe the palette is.
+ * A colour is not simply marked or unmarked. Each one serves several tags and
+ * those tags do not all carry the same mark: the comment colour is italic on a
+ * comment and plain on a fence marker, the heading colour is bold on a heading
+ * and underlined on a link. So a colour is the set of marks it appears with,
+ * and a pair is safe only when those sets are disjoint. Where both colours can
+ * appear plain, a reader who cannot separate the hues sees two identical runs,
+ * whatever either colour does elsewhere.
+ *
+ * This replaced a version recording one mark per colour, which read the
+ * stylesheet 18 collapses safer than it is.
+ *
+ * Keep in step with markyHighlightStyle. '' is no mark.
  */
-const NON_COLOUR_CUES: Record<string, string> = {
-  comment: 'italic',
-  error: 'wavy underline',
+const MARKS: Record<string, readonly string[]> = {
+  // t.heading is bold; t.link and t.url take the same colour underlined.
+  heading: ['bold', 'underline'],
+  // t.strong bold, t.emphasis italic, operators and punctuation plain.
+  foreground: ['bold', 'italic', ''],
+  // t.comment and t.quote are italic. t.processingInstruction and t.meta are
+  // not, and they draw the fence markers and the # of a heading.
+  comment: ['italic', ''],
+  // Shared with t.monospace, so a mark here would also mark inline code.
+  string: [''],
+  // t.list draws bullet markers in this colour. A mark here marks every bullet
+  // in the document, which is why the second bold went on tag instead.
+  keyword: [''],
+  // Code only, never markdown.
+  function: ['bold'],
+  class: [''],
+  constant: [''],
+  parameter: [''],
+  // t.tagName and t.angleBracket only, so this mark is invisible to markdown.
+  tag: ['bold'],
+  error: ['wavy'],
 };
 
 function isMitigated(conflict: string): boolean {
   const [a, b] = conflict.split(' ')[1].split('/');
-  return (NON_COLOUR_CUES[a] ?? '') !== (NON_COLOUR_CUES[b] ?? '');
+  const marksA = MARKS[a] ?? [''];
+  const marksB = MARKS[b] ?? [''];
+  return !marksA.some((mark) => marksB.includes(mark));
 }
 
 describe('syntax colours under colour vision deficiency', () => {
@@ -377,21 +407,25 @@ describe('syntax colours under colour vision deficiency', () => {
     expect(stale).toEqual([]);
   });
 
-  // The count that actually matters. Everything else survives on italics or a
-  // wavy underline; these are distinguishable by hue alone, so a reader with
-  // colour vision deficiency has nothing else to go on.
+  // The count that actually matters: pairs a reader has nothing but hue to go
+  // on for.
   //
-  // 80 of 175. Was 125 while the palette only had to clear contrast; solving
-  // the token lightnesses against each other as well took out 45 of them.
+  // 54 of 175. The history is worth keeping straight, because two of these
+  // numbers were measured with a model that was wrong:
   //
-  // 80 is an upper bound rather than a floor. The search moved lightness only,
-  // left hue and saturation alone, and hill-climbs from the current values, so
-  // it cannot reach an arrangement that needs a worse step first.
-  it('adds no colour-only collapse beyond the recorded 80', () => {
+  //   125  palette solved for contrast only, flat cue model
+  //    80  palette solved against itself as well, flat cue model
+  //    98  same palette, once the cue model stopped reading one mark per colour
+  //    54  bold on function and on tag
+  //
+  // 54 is an upper bound rather than a floor. The palette search moved
+  // lightness only and hill-climbs from the current values, so it cannot reach
+  // an arrangement that needs a worse step on the way.
+  it('adds no colour-only collapse beyond the recorded 54', () => {
     const bare = Object.entries(collapsed)
       .filter(([conflict]) => !isMitigated(conflict))
       .reduce((total, [, palettes]) => total + palettes.length, 0);
-    expect(bare).toBeLessThanOrEqual(80);
+    expect(bare).toBeLessThanOrEqual(54);
   });
 
   it('keeps error distinguishable by something other than hue', () => {


### PR DESCRIPTION
Step 3 of #26. Stacked on #42, so review that one first. GitHub will retarget this to `main` when #42 lands.

## The 80 in #42 was optimistic

The colour vision deficiency test discounts pairs that carry a non-colour cue, and it read those cues from a table of one mark per colour. That table was wrong in both directions:

- `heading` has been `fontWeight: 700` since forever. Never recorded.
- `comment: italic` is not true. `t.processingInstruction` and `t.meta` use the comment colour with no italic, and those draw the fence markers and the `#` of a heading.

The deeper problem is that one mark per colour cannot describe this. Each colour serves several tags and they do not all carry the same mark. So a colour is the *set* of marks it appears with, and a pair is safe only where those sets are disjoint. If both colours can appear plain, someone who cannot separate the hues sees two identical runs, whatever either colour does elsewhere.

Measured that way the real figure was **98**, not 80.

## What the bold buys

| | colour-only |
|---|---|
| as shipped, measured properly | 98 |
| `function` bold | 71 |
| `function` + `tag` bold | **54** |

`function` alone carries more collapses than any other token.

## Why tag and not keyword

They score the same, 54 either way, but they are not equivalent:

- `keyword` also colours `t.list`, so bolding it puts **every bullet marker in the document in bold**.
- `tag` is `t.tagName` and `t.angleBracket` only, which is embedded HTML. Invisible to markdown.

`function` is code-only too, so no markdown document renders differently after this.

`string` was worth checking and turned out worse than doing nothing (82): it shares its colour with `t.monospace`, and bold there collides with headings, which are already bold.

## No new underline

Agreed on avoiding it, and the model backs it up: underline is already the heading colour's mark on links, so a new underline would collide with it rather than separate anything.

## Still on the table

The largest single remaining lever is `comment` serving fence markers and `#` alongside actual comments. Making those italic would take this to 39, but italic fence markers look wrong. The alternative is giving structural markers their own token so `comment` becomes reliably italic — same result, no italics, but it is a bigger change and adds a colour that can itself collapse. Not in this PR.

Step 4 of #26 is untouched: nobody with colour vision deficiency has looked at any of this.

## Checks

Local: prettier clean, typecheck clean, 0 lint errors, 154 unit, 105 e2e.
